### PR TITLE
Added parsing of binaryheaders in RequestContext

### DIFF
--- a/grpc-client-utils/src/main/java/org/hypertrace/core/grpcutils/client/RequestContextAsCreds.java
+++ b/grpc-client-utils/src/main/java/org/hypertrace/core/grpcutils/client/RequestContextAsCreds.java
@@ -9,6 +9,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static io.grpc.Metadata.ASCII_STRING_MARSHALLER;
+import static io.grpc.Metadata.BINARY_BYTE_MARSHALLER;
 
 public abstract class RequestContextAsCreds extends CallCredentials {
   private static Logger LOGGER = LoggerFactory.getLogger(RequestContextAsCreds.class);
@@ -31,7 +32,12 @@ public abstract class RequestContextAsCreds extends CallCredentials {
       for (Map.Entry<String, String> entry : requestContext.getAll().entrySet()) {
         // Exclude null headers
         if (entry.getValue() != null) {
-          metadata.put(Metadata.Key.of(entry.getKey(), ASCII_STRING_MARSHALLER), entry.getValue());
+          String key = entry.getKey();
+          if (key.endsWith(Metadata.BINARY_HEADER_SUFFIX)) {
+            metadata.put(Metadata.Key.of(entry.getKey(), BINARY_BYTE_MARSHALLER), entry.getValue().getBytes());
+          } else {
+            metadata.put(Metadata.Key.of(entry.getKey(), ASCII_STRING_MARSHALLER), entry.getValue());
+          }
         }
       }
     }

--- a/grpc-client-utils/src/main/java/org/hypertrace/core/grpcutils/client/RequestContextAsCreds.java
+++ b/grpc-client-utils/src/main/java/org/hypertrace/core/grpcutils/client/RequestContextAsCreds.java
@@ -33,7 +33,7 @@ public abstract class RequestContextAsCreds extends CallCredentials {
         // Exclude null headers
         if (entry.getValue() != null) {
           String key = entry.getKey();
-          if (key.endsWith(Metadata.BINARY_HEADER_SUFFIX)) {
+          if (key.toLowerCase().endsWith(Metadata.BINARY_HEADER_SUFFIX)) {
             metadata.put(Metadata.Key.of(entry.getKey(), BINARY_BYTE_MARSHALLER), entry.getValue().getBytes());
           } else {
             metadata.put(Metadata.Key.of(entry.getKey(), ASCII_STRING_MARSHALLER), entry.getValue());

--- a/grpc-client-utils/src/test/java/org/hypertrace/core/grpcutils/client/GrpcClientRequestContextUtilTest.java
+++ b/grpc-client-utils/src/test/java/org/hypertrace/core/grpcutils/client/GrpcClientRequestContextUtilTest.java
@@ -62,6 +62,26 @@ public class GrpcClientRequestContextUtilTest {
   }
 
   @Test
+  public void testExecuteWithHeadersContextAuthAndTracing_shouldPropagateAllHeaders() {
+    Context ctx = Context.current();
+    Context previous = ctx.attach();
+    try {
+      Map<String, String> requestHeaders = Map.of("authorization", "v1", "a2", "v2",
+        "grpc-trace-bin", "AAARf5ZpQwlN/8FVe1axOPlaAQIdRU/Y8j0LAgE");
+
+      GrpcClientRequestContextUtil.executeWithHeadersContext(requestHeaders, () -> {
+        RequestContext requestContext = RequestContext.CURRENT.get();
+        Assertions.assertEquals(Map.of("authorization", "v1", "a2", "v2",
+          "grpc-trace-bin", "AAARf5ZpQwlN/8FVe1axOPlaAQIdRU/Y8j0LAgE"), requestContext.getRequestHeaders());
+        return new Object();
+      });
+    } finally {
+      ctx.detach(previous);
+    }
+  }
+
+
+  @Test
   public void testExecuteInTenantIdContext() {
     Assertions.assertNull(RequestContext.CURRENT.get());
     Assertions.assertEquals(Optional.of(TENANT_ID),

--- a/grpc-server-utils/src/main/java/org/hypertrace/core/grpcutils/server/RequestContextServerInterceptor.java
+++ b/grpc-server-utils/src/main/java/org/hypertrace/core/grpcutils/server/RequestContextServerInterceptor.java
@@ -45,7 +45,7 @@ public class RequestContextServerInterceptor implements ServerInterceptor {
         .forEach(k -> {
           String value;
           //check if key ends with binary suffix
-          if (k.endsWith(Metadata.BINARY_HEADER_SUFFIX)) {
+          if (k.toLowerCase().endsWith(Metadata.BINARY_HEADER_SUFFIX)) {
             byte[] bytes = metadata.get(Metadata.Key.of(k, Metadata.BINARY_BYTE_MARSHALLER));
             value = new String(bytes, StandardCharsets.UTF_8);
           } else {

--- a/grpc-server-utils/src/main/java/org/hypertrace/core/grpcutils/server/RequestContextServerInterceptor.java
+++ b/grpc-server-utils/src/main/java/org/hypertrace/core/grpcutils/server/RequestContextServerInterceptor.java
@@ -9,6 +9,8 @@ import io.grpc.ServerInterceptor;
 import org.hypertrace.core.grpcutils.context.RequestContext;
 import org.hypertrace.core.grpcutils.context.RequestContextConstants;
 
+import java.nio.charset.StandardCharsets;
+
 /**
  * Interceptor which intercepts the request headers to extract request context and sets it in the context so that the
  * server logic can use the context and they can be passed onto other downstream services.
@@ -41,7 +43,14 @@ public class RequestContextServerInterceptor implements ServerInterceptor {
             RequestContextConstants.HEADER_PREFIXES_TO_BE_PROPAGATED.stream()
                 .anyMatch(prefix -> k.toLowerCase().startsWith(prefix.toLowerCase())))
         .forEach(k -> {
-          String value = metadata.get(Metadata.Key.of(k, Metadata.ASCII_STRING_MARSHALLER));
+          String value;
+          //check if key ends with binary suffix
+          if (k.endsWith(Metadata.BINARY_HEADER_SUFFIX)) {
+            byte[] bytes = metadata.get(Metadata.Key.of(k, Metadata.BINARY_BYTE_MARSHALLER));
+            value = new String(bytes, StandardCharsets.UTF_8);
+          } else {
+            value = metadata.get(Metadata.Key.of(k, Metadata.ASCII_STRING_MARSHALLER));
+          }
           // The value could be null or empty for some keys so validate that.
           if (value != null && !value.isEmpty()) {
             requestContext.add(k, value);

--- a/grpc-server-utils/src/test/java/org/hypertrace/core/grpcutils/server/RequestContextServerInterceptorTests.java
+++ b/grpc-server-utils/src/test/java/org/hypertrace/core/grpcutils/server/RequestContextServerInterceptorTests.java
@@ -43,5 +43,19 @@ public class RequestContextServerInterceptorTests {
     Assertions.assertEquals(2, requestContext.getAll().size());
     Assertions.assertEquals("Bearer Some-bearer-auth-2", requestContext.get("authorization").get());
     Assertions.assertEquals("test-tenant-id-2", requestContext.get(RequestContextConstants.TENANT_ID_METADATA_KEY.name()).get());
+
+
+    metadata = new Metadata();
+    metadata.put(Metadata.Key.of("Authorization", Metadata.ASCII_STRING_MARSHALLER), "Bearer Some-bearer-auth-3");
+    metadata.put(Metadata.Key.of("X-tenant-Id", Metadata.ASCII_STRING_MARSHALLER), "test-tenant-id-3");
+    metadata.put(Metadata.Key.of("X-Some-Other-Header", Metadata.ASCII_STRING_MARSHALLER), "Some-other-header-val-3");
+    metadata.put(Metadata.Key.of("grpc-trace-bin", Metadata.BINARY_BYTE_MARSHALLER), "AAARf5ZpQwlN/8FVe1axOPlaAQIdRU/Y8j0LAgE".getBytes());
+
+    requestContext = interceptor.createRequestContextFromMetadata(metadata);
+
+    Assertions.assertEquals(3, requestContext.getAll().size());
+    Assertions.assertEquals("Bearer Some-bearer-auth-3", requestContext.get("authorization").get());
+    Assertions.assertEquals("test-tenant-id-3", requestContext.get(RequestContextConstants.TENANT_ID_METADATA_KEY.name()).get());
+    Assertions.assertEquals("AAARf5ZpQwlN/8FVe1axOPlaAQIdRU/Y8j0LAgE", requestContext.get("grpc-trace-bin").get());
   }
 }


### PR DESCRIPTION
Based on the name of the header, if the header ends with `-bin` then it is considered a binary header and a BINARY_BYTE_MARSHALLER is used in that case.