### PR TITLE
feat: add server call stream observer for rx

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,4 +15,11 @@ subprojects {
       license.set(License.APACHE_2_0)
     }
   }
+
+  pluginManager.withPlugin("java") {
+    configure<JavaPluginExtension> {
+      sourceCompatibility = JavaVersion.VERSION_11
+      targetCompatibility = JavaVersion.VERSION_11
+    }
+  }
 }

--- a/grpc-client-utils/build.gradle.kts
+++ b/grpc-client-utils/build.gradle.kts
@@ -13,9 +13,9 @@ dependencies {
   // End Logging
 
   // grpc
-  implementation("io.grpc:grpc-core:1.31.1")
+  implementation("io.grpc:grpc-core:1.32.1")
 
-  testImplementation("org.junit.jupiter:junit-jupiter:5.6.2")
+  testImplementation("org.junit.jupiter:junit-jupiter:5.7.0")
   testImplementation("org.mockito:mockito-core:3.4.4")
 }
 

--- a/grpc-context-utils/build.gradle.kts
+++ b/grpc-context-utils/build.gradle.kts
@@ -11,11 +11,11 @@ tasks.test {
 
 dependencies {
   // grpc
-  implementation("io.grpc:grpc-core:1.31.1")
+  implementation("io.grpc:grpc-core:1.32.1")
 
   // Logging
   implementation("org.slf4j:slf4j-api:1.7.30")
   // End Logging
 
-  testImplementation("org.junit.jupiter:junit-jupiter:5.6.2")
+  testImplementation("org.junit.jupiter:junit-jupiter:5.7.0")
 }

--- a/grpc-server-rx-utils/build.gradle.kts
+++ b/grpc-server-rx-utils/build.gradle.kts
@@ -8,8 +8,6 @@ plugins {
 dependencies {
   api("io.reactivex.rxjava3:rxjava:3.0.6")
   api("io.grpc:grpc-stub:1.32.1")
-  api(project(":grpc-context-utils"))
-  implementation("io.grpc:grpc-context:1.32.1")
 
   testImplementation("org.junit.jupiter:junit-jupiter:5.7.0")
   testImplementation("org.mockito:mockito-core:3.5.11")

--- a/grpc-server-rx-utils/src/main/java/org/hypertrace/core/grpcutils/server/rx/ServerCallStreamRxObserver.java
+++ b/grpc-server-rx-utils/src/main/java/org/hypertrace/core/grpcutils/server/rx/ServerCallStreamRxObserver.java
@@ -1,0 +1,45 @@
+package org.hypertrace.core.grpcutils.server.rx;
+
+import io.grpc.stub.ServerCallStreamObserver;
+import io.reactivex.rxjava3.annotations.NonNull;
+import io.reactivex.rxjava3.core.CompletableObserver;
+import io.reactivex.rxjava3.core.MaybeObserver;
+import io.reactivex.rxjava3.core.Observer;
+import io.reactivex.rxjava3.core.SingleObserver;
+import io.reactivex.rxjava3.observers.DefaultObserver;
+
+public class ServerCallStreamRxObserver<T> extends DefaultObserver<T>
+    implements Observer<T>, MaybeObserver<T>, SingleObserver<T>, CompletableObserver {
+
+  private final ServerCallStreamObserver<T> serverCallStreamObserver;
+
+  ServerCallStreamRxObserver(ServerCallStreamObserver<T> serverCallStreamObserver) {
+    this.serverCallStreamObserver = serverCallStreamObserver;
+  }
+
+  @Override
+  protected void onStart() {
+    this.serverCallStreamObserver.setOnCancelHandler(this::cancel);
+  }
+
+  @Override
+  public void onSuccess(@NonNull T value) {
+    this.onNext(value);
+    this.onComplete();
+  }
+
+  @Override
+  public void onNext(@NonNull T value) {
+    this.serverCallStreamObserver.onNext(value);
+  }
+
+  @Override
+  public void onError(@NonNull Throwable throwable) {
+    this.serverCallStreamObserver.onError(throwable);
+  }
+
+  @Override
+  public void onComplete() {
+    this.serverCallStreamObserver.onCompleted();
+  }
+}

--- a/grpc-server-rx-utils/src/main/java/org/hypertrace/core/grpcutils/server/rx/ServerCallStreamRxObserver.java
+++ b/grpc-server-rx-utils/src/main/java/org/hypertrace/core/grpcutils/server/rx/ServerCallStreamRxObserver.java
@@ -13,7 +13,7 @@ public class ServerCallStreamRxObserver<T> extends DefaultObserver<T>
 
   private final ServerCallStreamObserver<T> serverCallStreamObserver;
 
-  ServerCallStreamRxObserver(ServerCallStreamObserver<T> serverCallStreamObserver) {
+  public ServerCallStreamRxObserver(ServerCallStreamObserver<T> serverCallStreamObserver) {
     this.serverCallStreamObserver = serverCallStreamObserver;
   }
 

--- a/grpc-server-rx-utils/src/test/java/org/hypertrace/core/grpcutils/server/rx/ServerCallStreamRxObserverTest.java
+++ b/grpc-server-rx-utils/src/test/java/org/hypertrace/core/grpcutils/server/rx/ServerCallStreamRxObserverTest.java
@@ -1,0 +1,129 @@
+package org.hypertrace.core.grpcutils.server.rx;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import io.grpc.stub.ServerCallStreamObserver;
+import io.reactivex.rxjava3.core.Completable;
+import io.reactivex.rxjava3.core.Maybe;
+import io.reactivex.rxjava3.core.Observable;
+import io.reactivex.rxjava3.core.Single;
+import java.util.Arrays;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ServerCallStreamRxObserverTest {
+
+  @Mock ServerCallStreamObserver<Object> mockGrpcObserver;
+
+  @Test
+  void propagatesObservableValues() {
+    Observable.just("foo", "bar")
+        .blockingSubscribe(new ServerCallStreamRxObserver<>(this.mockGrpcObserver));
+    verifyValuesAndCompletion("foo", "bar");
+  }
+
+  @Test
+  void propagatesEmptyObservable() {
+    Observable.empty().blockingSubscribe(new ServerCallStreamRxObserver<>(this.mockGrpcObserver));
+    verifyValuesAndCompletion();
+  }
+
+  @Test
+  void propagatesSingleValue() {
+    Single.just("single")
+        .blockingSubscribe(new ServerCallStreamRxObserver<>(this.mockGrpcObserver));
+    verifyValuesAndCompletion("single");
+  }
+
+  @Test
+  void propagatesMaybeValue() {
+    Maybe.just("maybe").blockingSubscribe(new ServerCallStreamRxObserver<>(this.mockGrpcObserver));
+    verifyValuesAndCompletion("maybe");
+  }
+
+  @Test
+  void propagatesEmptyMaybe() {
+    Maybe.empty().blockingSubscribe(new ServerCallStreamRxObserver<>(this.mockGrpcObserver));
+    verifyValuesAndCompletion();
+  }
+
+  @Test
+  void propagatesCompletableCompletion() {
+    Completable.complete()
+        .blockingSubscribe(new ServerCallStreamRxObserver<>(this.mockGrpcObserver));
+    verifyValuesAndCompletion();
+  }
+
+  @Test
+  void propagatesObservableError() {
+    Throwable error = new IllegalArgumentException("observable");
+    Observable.error(error)
+        .blockingSubscribe(new ServerCallStreamRxObserver<>(this.mockGrpcObserver));
+    verifyThrows(error);
+  }
+
+  @Test
+  void propagateSingleError() {
+    Throwable error = new IllegalArgumentException("single");
+    Single.error(error).blockingSubscribe(new ServerCallStreamRxObserver<>(this.mockGrpcObserver));
+    verifyThrows(error);
+  }
+
+  @Test
+  void propagatesMaybeError() {
+    Throwable error = new IllegalArgumentException("maybe");
+    Maybe.error(error).blockingSubscribe(new ServerCallStreamRxObserver<>(this.mockGrpcObserver));
+    verifyThrows(error);
+  }
+
+  @Test
+  void propagatesCompletableError() {
+    Throwable error = new IllegalArgumentException("completable");
+    Completable.error(error)
+        .blockingSubscribe(new ServerCallStreamRxObserver<>(this.mockGrpcObserver));
+    verifyThrows(error);
+  }
+
+  @Test
+  void propagatesCancellationRequest() {
+    Observable.just("first", "second")
+        .doAfterNext(
+            value -> {
+              // Capture the cancellation handler and invoke it to prevent values beyond the first
+              ArgumentCaptor<Runnable> captor = ArgumentCaptor.forClass(Runnable.class);
+              verify(this.mockGrpcObserver).setOnCancelHandler(captor.capture());
+              captor.getValue().run();
+            })
+        .subscribe(new ServerCallStreamRxObserver<>(this.mockGrpcObserver));
+
+    verify(this.mockGrpcObserver).onNext("first");
+    verifyNoMoreInteractions(this.mockGrpcObserver);
+  }
+
+  private void verifyValuesAndCompletion(String... values) {
+    InOrder callOrder = inOrder(this.mockGrpcObserver);
+
+    callOrder.verify(this.mockGrpcObserver).setOnCancelHandler(any());
+    Arrays.asList(values).forEach(value -> callOrder.verify(this.mockGrpcObserver).onNext(value));
+    callOrder.verify(this.mockGrpcObserver).onCompleted();
+
+    verifyNoMoreInteractions(this.mockGrpcObserver);
+  }
+
+  private void verifyThrows(Throwable throwable) {
+    InOrder callOrder = inOrder(this.mockGrpcObserver);
+
+    callOrder.verify(this.mockGrpcObserver).setOnCancelHandler(any());
+    callOrder.verify(this.mockGrpcObserver).onError(throwable);
+
+    verifyNoMoreInteractions(this.mockGrpcObserver);
+  }
+}

--- a/grpc-server-utils/build.gradle.kts
+++ b/grpc-server-utils/build.gradle.kts
@@ -17,7 +17,7 @@ dependencies {
   // End Logging
 
   // grpc
-  implementation("io.grpc:grpc-core:1.31.1")
+  implementation("io.grpc:grpc-core:1.32.1")
 
-  testImplementation("org.junit.jupiter:junit-jupiter:5.6.2")
+  testImplementation("org.junit.jupiter:junit-jupiter:5.7.0")
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -14,5 +14,6 @@ plugins {
 
 include(":grpc-client-utils")
 include(":grpc-client-rx-utils")
+include(":grpc-server-rx-utils")
 include(":grpc-context-utils")
 include(":grpc-server-utils")


### PR DESCRIPTION
This change adds an RxJava adapter to support converting a reactive construct (Observable, Single, Maybe, Completable - didn't add flowable support unless needed) into a GRPC response. This pattern:
- Promotes cleaner code, as an observer no longer needs to be plumbed down throw the call stack
- Supports either synchronous or async implementations (like any reactive code)
- Supports cancellation for ongoing requests