### PR TITLE
fix: unwrap thrown exceptions

### DIFF
--- a/grpc-client-rx-utils/build.gradle.kts
+++ b/grpc-client-rx-utils/build.gradle.kts
@@ -7,14 +7,9 @@ plugins {
 
 dependencies {
   api("io.reactivex.rxjava3:rxjava:3.0.6")
-  api("io.grpc:grpc-stub:1.33.1")
+  api("io.grpc:grpc-stub:1.35.0")
   api(project(":grpc-context-utils"))
-  implementation("io.grpc:grpc-context:1.33.1")
-  constraints {
-    implementation("com.google.guava:guava:30.0-jre") {
-      because("https://snyk.io/vuln/SNYK-JAVA-COMGOOGLEGUAVA-1015415")
-    }
-  }
+  implementation("io.grpc:grpc-context:1.35.0")
 
   testImplementation("org.junit.jupiter:junit-jupiter:5.7.0")
   testImplementation("org.mockito:mockito-core:3.5.11")

--- a/grpc-client-utils/build.gradle.kts
+++ b/grpc-client-utils/build.gradle.kts
@@ -13,7 +13,7 @@ dependencies {
   // End Logging
 
   // grpc
-  implementation("io.grpc:grpc-core:1.33.1")
+  implementation("io.grpc:grpc-core:1.35.0")
   constraints {
     implementation("com.google.guava:guava:30.0-jre") {
       because("https://snyk.io/vuln/SNYK-JAVA-COMGOOGLEGUAVA-1015415")

--- a/grpc-client-utils/src/main/java/org/hypertrace/core/grpcutils/client/GrpcClientRequestContextUtil.java
+++ b/grpc-client-utils/src/main/java/org/hypertrace/core/grpcutils/client/GrpcClientRequestContextUtil.java
@@ -44,6 +44,9 @@ public class GrpcClientRequestContextUtil {
     try {
       return Context.current().withValue(RequestContext.CURRENT, requestContext).call(c);
     } catch (Exception e) {
+      if (e instanceof RuntimeException) {
+        throw (RuntimeException)e;
+      }
       throw new RuntimeException(e);
     }
   }
@@ -58,10 +61,6 @@ public class GrpcClientRequestContextUtil {
     RequestContext requestContext = new RequestContext();
     headers.forEach(requestContext::add);
 
-    try {
-      Context.current().withValue(RequestContext.CURRENT, requestContext).run(r);
-    } catch (Exception e) {
-      throw new RuntimeException(e);
-    }
+    Context.current().withValue(RequestContext.CURRENT, requestContext).run(r);
   }
 }

--- a/grpc-client-utils/src/test/java/org/hypertrace/core/grpcutils/client/GrpcClientRequestContextUtilTest.java
+++ b/grpc-client-utils/src/test/java/org/hypertrace/core/grpcutils/client/GrpcClientRequestContextUtilTest.java
@@ -121,7 +121,18 @@ public class GrpcClientRequestContextUtilTest {
   }
 
   @Test
-  public void testExecuteWithHeadersContextThrowsRuntimeExceptionWhenRunnableThrowsException() {
+  public void testExecuteWithHeadersContextRethrowsRuntimeException() {
+    Map<String, String> headers = Map.of("a1", "v1", "a2", "v2");
+    Assertions.assertThrows(IllegalArgumentException.class, () -> {
+      GrpcClientRequestContextUtil.executeWithHeadersContext(headers,
+          () -> {
+            throw new IllegalArgumentException("test exception");
+          });
+    });
+  }
+
+  @Test
+  public void testExecuteWithHeadersContextWrapsCheckedException() {
     Map<String, String> headers = Map.of("a1", "v1", "a2", "v2");
     Assertions.assertThrows(RuntimeException.class, () -> {
       GrpcClientRequestContextUtil.executeWithHeadersContext(headers,

--- a/grpc-context-utils/build.gradle.kts
+++ b/grpc-context-utils/build.gradle.kts
@@ -11,7 +11,7 @@ tasks.test {
 
 dependencies {
   // grpc
-  implementation("io.grpc:grpc-core:1.33.1")
+  implementation("io.grpc:grpc-core:1.35.0")
   constraints {
     implementation("com.google.guava:guava:30.0-jre") {
       because("https://snyk.io/vuln/SNYK-JAVA-COMGOOGLEGUAVA-1015415")

--- a/grpc-server-rx-utils/build.gradle.kts
+++ b/grpc-server-rx-utils/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 
 dependencies {
   api("io.reactivex.rxjava3:rxjava:3.0.6")
-  api("io.grpc:grpc-stub:1.33.1")
+  api("io.grpc:grpc-stub:1.35.0")
   constraints {
     implementation("com.google.guava:guava:30.0-jre") {
       because("https://snyk.io/vuln/SNYK-JAVA-COMGOOGLEGUAVA-1015415")

--- a/grpc-server-utils/build.gradle.kts
+++ b/grpc-server-utils/build.gradle.kts
@@ -17,7 +17,7 @@ dependencies {
   // End Logging
 
   // grpc
-  implementation("io.grpc:grpc-core:1.33.1")
+  implementation("io.grpc:grpc-core:1.35.0")
   constraints {
     implementation("com.google.guava:guava:30.0-jre") {
       because("https://snyk.io/vuln/SNYK-JAVA-COMGOOGLEGUAVA-1015415")


### PR DESCRIPTION
This changes the behavior of the execution utils to stop wrapping any thrown exceptions. This behavior was only meant to satisfy the compiler, and makes it more difficult to react based on the type of error.