### PR TITLE
ENG-9494 expose roles in request context

### DIFF
--- a/grpc-context-utils/src/main/java/org/hypertrace/core/grpcutils/context/Jwt.java
+++ b/grpc-context-utils/src/main/java/org/hypertrace/core/grpcutils/context/Jwt.java
@@ -1,7 +1,7 @@
 package org.hypertrace.core.grpcutils.context;
 
+import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 
 interface Jwt {
   Optional<String> getUserId();
@@ -12,5 +12,5 @@ interface Jwt {
 
   Optional<String> getEmail();
 
-  Set<String> getRoles();
+  List<String> getRoles();
 }

--- a/grpc-context-utils/src/main/java/org/hypertrace/core/grpcutils/context/Jwt.java
+++ b/grpc-context-utils/src/main/java/org/hypertrace/core/grpcutils/context/Jwt.java
@@ -1,6 +1,7 @@
 package org.hypertrace.core.grpcutils.context;
 
 import java.util.Optional;
+import java.util.Set;
 
 interface Jwt {
   Optional<String> getUserId();
@@ -10,4 +11,6 @@ interface Jwt {
   Optional<String> getPictureUrl();
 
   Optional<String> getEmail();
+
+  Set<String> getRoles();
 }

--- a/grpc-context-utils/src/main/java/org/hypertrace/core/grpcutils/context/Jwt.java
+++ b/grpc-context-utils/src/main/java/org/hypertrace/core/grpcutils/context/Jwt.java
@@ -12,5 +12,5 @@ interface Jwt {
 
   Optional<String> getEmail();
 
-  List<String> getRoles();
+  List<String> getRoles(String rolesClaim);
 }

--- a/grpc-context-utils/src/main/java/org/hypertrace/core/grpcutils/context/JwtParser.java
+++ b/grpc-context-utils/src/main/java/org/hypertrace/core/grpcutils/context/JwtParser.java
@@ -1,16 +1,13 @@
 package org.hypertrace.core.grpcutils.context;
 
 import com.auth0.jwt.JWT;
-import com.auth0.jwt.interfaces.Claim;
 import com.auth0.jwt.interfaces.DecodedJWT;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import org.slf4j.Logger;
@@ -55,7 +52,6 @@ class JwtParser {
     private static final String NAME_CLAIM = "name";
     private static final String PICTURE_CLAIM = "picture";
     private static final String EMAIL_CLAIM = "email";
-    private static final String ROLES_CLAIM = "https://traceable.ai/roles";
 
     private DefaultJwt(DecodedJWT jwt) {
       this.jwt = jwt;
@@ -82,8 +78,8 @@ class JwtParser {
     }
 
     @Override
-    public List<String> getRoles() {
-      List<String> roles = jwt.getClaim(ROLES_CLAIM).asList(String.class);
+    public List<String> getRoles(String rolesClaim) {
+      List<String> roles = jwt.getClaim(rolesClaim).asList(String.class);
       if (roles == null || roles.isEmpty()) {
         return Collections.emptyList();
       }

--- a/grpc-context-utils/src/main/java/org/hypertrace/core/grpcutils/context/JwtParser.java
+++ b/grpc-context-utils/src/main/java/org/hypertrace/core/grpcutils/context/JwtParser.java
@@ -5,6 +5,7 @@ import com.auth0.jwt.interfaces.DecodedJWT;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import org.slf4j.Logger;
@@ -49,6 +50,7 @@ class JwtParser {
     private static final String NAME_CLAIM = "name";
     private static final String PICTURE_CLAIM = "picture";
     private static final String EMAIL_CLAIM = "email";
+    private static final String ROLES_CLAIM = "https://traceable.ai/roles";
 
     private DefaultJwt(DecodedJWT jwt) {
       this.jwt = jwt;
@@ -72,6 +74,11 @@ class JwtParser {
     @Override
     public Optional<String> getEmail() {
       return Optional.ofNullable(jwt.getClaim(EMAIL_CLAIM).asString());
+    }
+
+    @Override
+    public Set<String> getRoles() {
+      return null;
     }
   }
 }

--- a/grpc-context-utils/src/main/java/org/hypertrace/core/grpcutils/context/JwtParser.java
+++ b/grpc-context-utils/src/main/java/org/hypertrace/core/grpcutils/context/JwtParser.java
@@ -82,12 +82,12 @@ class JwtParser {
     }
 
     @Override
-    public Set<String> getRoles() {
+    public List<String> getRoles() {
       List<String> roles = jwt.getClaim(ROLES_CLAIM).asList(String.class);
       if (roles == null || roles.isEmpty()) {
-        return Collections.emptySet();
+        return Collections.emptyList();
       }
-      return new HashSet<>(roles);
+      return roles;
     }
   }
 }

--- a/grpc-context-utils/src/main/java/org/hypertrace/core/grpcutils/context/JwtParser.java
+++ b/grpc-context-utils/src/main/java/org/hypertrace/core/grpcutils/context/JwtParser.java
@@ -1,11 +1,14 @@
 package org.hypertrace.core.grpcutils.context;
 
 import com.auth0.jwt.JWT;
+import com.auth0.jwt.interfaces.Claim;
 import com.auth0.jwt.interfaces.DecodedJWT;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 
+import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
@@ -80,7 +83,11 @@ class JwtParser {
 
     @Override
     public Set<String> getRoles() {
-      return new HashSet<>(jwt.getClaim(ROLES_CLAIM).asList(String.class));
+      List<String> roles = jwt.getClaim(ROLES_CLAIM).asList(String.class);
+      if (roles == null || roles.isEmpty()) {
+        return Collections.emptySet();
+      }
+      return new HashSet<>(roles);
     }
   }
 }

--- a/grpc-context-utils/src/main/java/org/hypertrace/core/grpcutils/context/JwtParser.java
+++ b/grpc-context-utils/src/main/java/org/hypertrace/core/grpcutils/context/JwtParser.java
@@ -4,6 +4,8 @@ import com.auth0.jwt.JWT;
 import com.auth0.jwt.interfaces.DecodedJWT;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
+
+import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
@@ -78,7 +80,7 @@ class JwtParser {
 
     @Override
     public Set<String> getRoles() {
-      return null;
+      return new HashSet<>(jwt.getClaim(ROLES_CLAIM).asList(String.class));
     }
   }
 }

--- a/grpc-context-utils/src/main/java/org/hypertrace/core/grpcutils/context/RequestContext.java
+++ b/grpc-context-utils/src/main/java/org/hypertrace/core/grpcutils/context/RequestContext.java
@@ -4,9 +4,9 @@ import io.grpc.Context;
 
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import java.util.concurrent.Callable;
 import javax.annotation.Nonnull;
 
@@ -47,8 +47,8 @@ public class RequestContext {
     return getJwt().flatMap(Jwt::getEmail);
   }
 
-  public Set<String> getRoles() {
-    return getJwt().map(Jwt::getRoles).orElse(Collections.emptySet());
+  public List<String> getRoles() {
+    return getJwt().map(Jwt::getRoles).orElse(Collections.emptyList());
   }
 
   private Optional<Jwt> getJwt() {

--- a/grpc-context-utils/src/main/java/org/hypertrace/core/grpcutils/context/RequestContext.java
+++ b/grpc-context-utils/src/main/java/org/hypertrace/core/grpcutils/context/RequestContext.java
@@ -47,8 +47,8 @@ public class RequestContext {
     return getJwt().flatMap(Jwt::getEmail);
   }
 
-  public List<String> getRoles() {
-    return getJwt().map(Jwt::getRoles).orElse(Collections.emptyList());
+  public List<String> getRoles(String rolesClaim) {
+    return getJwt().map(jwt -> jwt.getRoles(rolesClaim)).orElse(Collections.emptyList());
   }
 
   private Optional<Jwt> getJwt() {

--- a/grpc-context-utils/src/main/java/org/hypertrace/core/grpcutils/context/RequestContext.java
+++ b/grpc-context-utils/src/main/java/org/hypertrace/core/grpcutils/context/RequestContext.java
@@ -1,9 +1,12 @@
 package org.hypertrace.core.grpcutils.context;
 
 import io.grpc.Context;
+
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.Callable;
 import javax.annotation.Nonnull;
 
@@ -42,6 +45,10 @@ public class RequestContext {
 
   public Optional<String> getEmail() {
     return getJwt().flatMap(Jwt::getEmail);
+  }
+
+  public Set<String> getRoles() {
+    return getJwt().map(Jwt::getRoles).orElse(Collections.emptySet());
   }
 
   private Optional<Jwt> getJwt() {

--- a/grpc-context-utils/src/test/java/org/hypertrace/core/grpcutils/context/JwtParserTest.java
+++ b/grpc-context-utils/src/test/java/org/hypertrace/core/grpcutils/context/JwtParserTest.java
@@ -17,13 +17,14 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
 
 class JwtParserTest {
-  private final String testJwt = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJPbmxpbmUgSldUIEJ1aWxkZXIiLCJpYXQiOjE2MjEzNjM1OTcsImV4cCI6MTY1Mjg5OTU5NywiYXVkIjoid3d3LmV4YW1wbGUuY29tIiwic3ViIjoianJvY2tldEBleGFtcGxlLmNvbSIsIkdpdmVuTmFtZSI6IkpvaG5ueSIsIlN1cm5hbWUiOiJSb2NrZXQiLCJuYW1lIjoiSm9obm55IFJvY2tldCIsImVtYWlsIjoianJvY2tldEBleGFtcGxlLmNvbSIsInBpY3R1cmUiOiJ3d3cuZXhhbXBsZS5jb20iLCJodHRwczovL3RyYWNlYWJsZS5haS9yb2xlcyI6WyJzdXBlcl91c2VyIiwidXNlciIsImJpbGxpbmdfYWRtaW4iXX0.hcGrulbxkDDJhWuos18iQzpFjPBmlF6xt6wKusB2ZYg";
+  private final String testJwt = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJPbmxpbmUgSldUIEJ1aWxkZXIiLCJpYXQiOjE2MjEzNjM1OTcsImV4cCI6MTY1Mjg5OTU5NywiYXVkIjoid3d3LmV4YW1wbGUuY29tIiwic3ViIjoianJvY2tldEBleGFtcGxlLmNvbSIsIkdpdmVuTmFtZSI6IkpvaG5ueSIsIlN1cm5hbWUiOiJSb2NrZXQiLCJuYW1lIjoiSm9obm55IFJvY2tldCIsImVtYWlsIjoianJvY2tldEBleGFtcGxlLmNvbSIsInBpY3R1cmUiOiJ3d3cuZXhhbXBsZS5jb20iLCJyb2xlcyI6WyJzdXBlcl91c2VyIiwidXNlciIsImJpbGxpbmdfYWRtaW4iXX0.lEDjPPCjr-Epv6pNslq-HK9vmxfstp1sY85GstlbU1I";
   private final String emptyRolesJwt = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJPbmxpbmUgSldUIEJ1aWxkZXIiLCJpYXQiOjE2MjEzNjM1OTcsImV4cCI6MTY1Mjg5OTU5NywiYXVkIjoid3d3LmV4YW1wbGUuY29tIiwic3ViIjoianJvY2tldEBleGFtcGxlLmNvbSIsIkdpdmVuTmFtZSI6IkpvaG5ueSIsIlN1cm5hbWUiOiJSb2NrZXQiLCJuYW1lIjoiSm9obm55IFJvY2tldCIsImVtYWlsIjoianJvY2tldEBleGFtcGxlLmNvbSIsInBpY3R1cmUiOiJ3d3cuZXhhbXBsZS5jb20iLCJodHRwczovL3RyYWNlYWJsZS5haS9yb2xlcyI6W119.sFUMZNyypj379xy5P4kqTbBXBOR5XvX2nhpKx6YiiwU";
   private final String noRolesJwt = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJPbmxpbmUgSldUIEJ1aWxkZXIiLCJpYXQiOjE2MjEzNjM1OTcsImV4cCI6MTY1Mjg5OTU5NywiYXVkIjoid3d3LmV4YW1wbGUuY29tIiwic3ViIjoianJvY2tldEBleGFtcGxlLmNvbSIsIkdpdmVuTmFtZSI6IkpvaG5ueSIsIlN1cm5hbWUiOiJSb2NrZXQiLCJuYW1lIjoiSm9obm55IFJvY2tldCIsImVtYWlsIjoianJvY2tldEBleGFtcGxlLmNvbSIsInBpY3R1cmUiOiJ3d3cuZXhhbXBsZS5jb20ifQ.Ui1Z2RhiVe3tq6uJPgcyjsfDBdeOeINs_gXEHC6cdpU";
   private final String testJwtUserId = "jrocket@example.com";
   private final String testJwtName = "Johnny Rocket";
   private final String testJwtPictureUrl = "www.example.com";
   private final String testJwtEmail = "jrocket@example.com";
+  private final String testRolesClaim = "roles";
   private final List<String> testRoles = ImmutableList.of("super_user", "user", "billing_admin");
 
   @Test
@@ -65,20 +66,20 @@ class JwtParserTest {
   void testRolesCanBeParsedFromToken() {
     JwtParser parser = new JwtParser();
     Optional<Jwt> jwt = parser.fromJwt(testJwt);
-    assertEquals(Optional.of(testRoles), jwt.map(Jwt::getRoles));
+    assertEquals(Optional.of(testRoles), jwt.map(j -> j.getRoles(testRolesClaim)));
   }
 
   @Test
   void testRolesAreEmptyIfRolesArrayIsEmptyInJwt() {
     JwtParser parser = new JwtParser();
     Optional<Jwt> jwt = parser.fromJwt(emptyRolesJwt);
-    assertEquals(Optional.of(Collections.emptyList()), jwt.map(Jwt::getRoles));
+    assertEquals(Optional.of(Collections.emptyList()), jwt.map(j -> j.getRoles(testRolesClaim)));
   }
 
   @Test
   void testRolesAreEmptyIfRolesIfNoRolesClaimInToken() {
     JwtParser parser = new JwtParser();
     Optional<Jwt> jwt = parser.fromJwt(noRolesJwt);
-    assertEquals(Optional.of(Collections.emptyList()), jwt.map(Jwt::getRoles));
+    assertEquals(Optional.of(Collections.emptyList()), jwt.map(j -> j.getRoles(testRolesClaim)));
   }
 }

--- a/grpc-context-utils/src/test/java/org/hypertrace/core/grpcutils/context/JwtParserTest.java
+++ b/grpc-context-utils/src/test/java/org/hypertrace/core/grpcutils/context/JwtParserTest.java
@@ -19,6 +19,7 @@ import org.mockito.ArgumentMatchers;
 class JwtParserTest {
   private final String testJwt = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJPbmxpbmUgSldUIEJ1aWxkZXIiLCJpYXQiOjE2MjEzNjM1OTcsImV4cCI6MTY1Mjg5OTU5NywiYXVkIjoid3d3LmV4YW1wbGUuY29tIiwic3ViIjoianJvY2tldEBleGFtcGxlLmNvbSIsIkdpdmVuTmFtZSI6IkpvaG5ueSIsIlN1cm5hbWUiOiJSb2NrZXQiLCJuYW1lIjoiSm9obm55IFJvY2tldCIsImVtYWlsIjoianJvY2tldEBleGFtcGxlLmNvbSIsInBpY3R1cmUiOiJ3d3cuZXhhbXBsZS5jb20iLCJodHRwczovL3RyYWNlYWJsZS5haS9yb2xlcyI6WyJ0cmFjZWFibGUiLCJ1c2VyIiwiYmlsbGluZ19hZG1pbiJdfQ.xdWar7cgJ_5V3SgECanVtBMhxJGb-DbeIfrKSpAQLJM";
   private final String emptyRolesJwt = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJPbmxpbmUgSldUIEJ1aWxkZXIiLCJpYXQiOjE2MjEzNjM1OTcsImV4cCI6MTY1Mjg5OTU5NywiYXVkIjoid3d3LmV4YW1wbGUuY29tIiwic3ViIjoianJvY2tldEBleGFtcGxlLmNvbSIsIkdpdmVuTmFtZSI6IkpvaG5ueSIsIlN1cm5hbWUiOiJSb2NrZXQiLCJuYW1lIjoiSm9obm55IFJvY2tldCIsImVtYWlsIjoianJvY2tldEBleGFtcGxlLmNvbSIsInBpY3R1cmUiOiJ3d3cuZXhhbXBsZS5jb20iLCJodHRwczovL3RyYWNlYWJsZS5haS9yb2xlcyI6W119.sFUMZNyypj379xy5P4kqTbBXBOR5XvX2nhpKx6YiiwU";
+  private final String noRolesJwt = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJPbmxpbmUgSldUIEJ1aWxkZXIiLCJpYXQiOjE2MjEzNjM1OTcsImV4cCI6MTY1Mjg5OTU5NywiYXVkIjoid3d3LmV4YW1wbGUuY29tIiwic3ViIjoianJvY2tldEBleGFtcGxlLmNvbSIsIkdpdmVuTmFtZSI6IkpvaG5ueSIsIlN1cm5hbWUiOiJSb2NrZXQiLCJuYW1lIjoiSm9obm55IFJvY2tldCIsImVtYWlsIjoianJvY2tldEBleGFtcGxlLmNvbSIsInBpY3R1cmUiOiJ3d3cuZXhhbXBsZS5jb20ifQ.Ui1Z2RhiVe3tq6uJPgcyjsfDBdeOeINs_gXEHC6cdpU";
   private final String testJwtUserId = "jrocket@example.com";
   private final String testJwtName = "Johnny Rocket";
   private final String testJwtPictureUrl = "www.example.com";
@@ -73,4 +74,12 @@ class JwtParserTest {
     Optional<Jwt> jwt = parser.fromJwt(emptyRolesJwt);
     assertEquals(Optional.of(Collections.emptySet()), jwt.flatMap(j -> Optional.of(j.getRoles())));
   }
+
+  @Test
+  void testRolesAreEmptyIfRolesIfNoRolesClaimInToken() {
+    JwtParser parser = new JwtParser();
+    Optional<Jwt> jwt = parser.fromJwt(noRolesJwt);
+    assertEquals(Optional.of(Collections.emptySet()), jwt.flatMap(j -> Optional.of(j.getRoles())));
+  }
+
 }

--- a/grpc-context-utils/src/test/java/org/hypertrace/core/grpcutils/context/JwtParserTest.java
+++ b/grpc-context-utils/src/test/java/org/hypertrace/core/grpcutils/context/JwtParserTest.java
@@ -9,22 +9,22 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 
-import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableList;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
 
 class JwtParserTest {
-  private final String testJwt = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJPbmxpbmUgSldUIEJ1aWxkZXIiLCJpYXQiOjE2MjEzNjM1OTcsImV4cCI6MTY1Mjg5OTU5NywiYXVkIjoid3d3LmV4YW1wbGUuY29tIiwic3ViIjoianJvY2tldEBleGFtcGxlLmNvbSIsIkdpdmVuTmFtZSI6IkpvaG5ueSIsIlN1cm5hbWUiOiJSb2NrZXQiLCJuYW1lIjoiSm9obm55IFJvY2tldCIsImVtYWlsIjoianJvY2tldEBleGFtcGxlLmNvbSIsInBpY3R1cmUiOiJ3d3cuZXhhbXBsZS5jb20iLCJodHRwczovL3RyYWNlYWJsZS5haS9yb2xlcyI6WyJ0cmFjZWFibGUiLCJ1c2VyIiwiYmlsbGluZ19hZG1pbiJdfQ.xdWar7cgJ_5V3SgECanVtBMhxJGb-DbeIfrKSpAQLJM";
+  private final String testJwt = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJPbmxpbmUgSldUIEJ1aWxkZXIiLCJpYXQiOjE2MjEzNjM1OTcsImV4cCI6MTY1Mjg5OTU5NywiYXVkIjoid3d3LmV4YW1wbGUuY29tIiwic3ViIjoianJvY2tldEBleGFtcGxlLmNvbSIsIkdpdmVuTmFtZSI6IkpvaG5ueSIsIlN1cm5hbWUiOiJSb2NrZXQiLCJuYW1lIjoiSm9obm55IFJvY2tldCIsImVtYWlsIjoianJvY2tldEBleGFtcGxlLmNvbSIsInBpY3R1cmUiOiJ3d3cuZXhhbXBsZS5jb20iLCJodHRwczovL3RyYWNlYWJsZS5haS9yb2xlcyI6WyJzdXBlcl91c2VyIiwidXNlciIsImJpbGxpbmdfYWRtaW4iXX0.hcGrulbxkDDJhWuos18iQzpFjPBmlF6xt6wKusB2ZYg";
   private final String emptyRolesJwt = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJPbmxpbmUgSldUIEJ1aWxkZXIiLCJpYXQiOjE2MjEzNjM1OTcsImV4cCI6MTY1Mjg5OTU5NywiYXVkIjoid3d3LmV4YW1wbGUuY29tIiwic3ViIjoianJvY2tldEBleGFtcGxlLmNvbSIsIkdpdmVuTmFtZSI6IkpvaG5ueSIsIlN1cm5hbWUiOiJSb2NrZXQiLCJuYW1lIjoiSm9obm55IFJvY2tldCIsImVtYWlsIjoianJvY2tldEBleGFtcGxlLmNvbSIsInBpY3R1cmUiOiJ3d3cuZXhhbXBsZS5jb20iLCJodHRwczovL3RyYWNlYWJsZS5haS9yb2xlcyI6W119.sFUMZNyypj379xy5P4kqTbBXBOR5XvX2nhpKx6YiiwU";
   private final String noRolesJwt = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJPbmxpbmUgSldUIEJ1aWxkZXIiLCJpYXQiOjE2MjEzNjM1OTcsImV4cCI6MTY1Mjg5OTU5NywiYXVkIjoid3d3LmV4YW1wbGUuY29tIiwic3ViIjoianJvY2tldEBleGFtcGxlLmNvbSIsIkdpdmVuTmFtZSI6IkpvaG5ueSIsIlN1cm5hbWUiOiJSb2NrZXQiLCJuYW1lIjoiSm9obm55IFJvY2tldCIsImVtYWlsIjoianJvY2tldEBleGFtcGxlLmNvbSIsInBpY3R1cmUiOiJ3d3cuZXhhbXBsZS5jb20ifQ.Ui1Z2RhiVe3tq6uJPgcyjsfDBdeOeINs_gXEHC6cdpU";
   private final String testJwtUserId = "jrocket@example.com";
   private final String testJwtName = "Johnny Rocket";
   private final String testJwtPictureUrl = "www.example.com";
   private final String testJwtEmail = "jrocket@example.com";
-  private final Set<String> testRoles = ImmutableSet.of("traceable", "user", "billing_admin");
+  private final List<String> testRoles = ImmutableList.of("super_user", "user", "billing_admin");
 
   @Test
   void testGoodJwtParse() {
@@ -62,7 +62,7 @@ class JwtParserTest {
   }
 
   @Test
-  void testTraceableRolesCanBeParsedFromToken() {
+  void testRolesCanBeParsedFromToken() {
     JwtParser parser = new JwtParser();
     Optional<Jwt> jwt = parser.fromJwt(testJwt);
     assertEquals(Optional.of(testRoles), jwt.map(Jwt::getRoles));
@@ -72,14 +72,13 @@ class JwtParserTest {
   void testRolesAreEmptyIfRolesArrayIsEmptyInJwt() {
     JwtParser parser = new JwtParser();
     Optional<Jwt> jwt = parser.fromJwt(emptyRolesJwt);
-    assertEquals(Optional.of(Collections.emptySet()), jwt.map(Jwt::getRoles));
+    assertEquals(Optional.of(Collections.emptyList()), jwt.map(Jwt::getRoles));
   }
 
   @Test
   void testRolesAreEmptyIfRolesIfNoRolesClaimInToken() {
     JwtParser parser = new JwtParser();
     Optional<Jwt> jwt = parser.fromJwt(noRolesJwt);
-    assertEquals(Optional.of(Collections.emptySet()), jwt.map(Jwt::getRoles));
+    assertEquals(Optional.of(Collections.emptyList()), jwt.map(Jwt::getRoles));
   }
-
 }

--- a/grpc-context-utils/src/test/java/org/hypertrace/core/grpcutils/context/JwtParserTest.java
+++ b/grpc-context-utils/src/test/java/org/hypertrace/core/grpcutils/context/JwtParserTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.Collections;
 import java.util.Optional;
 import java.util.Set;
 
@@ -17,6 +18,7 @@ import org.mockito.ArgumentMatchers;
 
 class JwtParserTest {
   private final String testJwt = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJPbmxpbmUgSldUIEJ1aWxkZXIiLCJpYXQiOjE2MjEzNjM1OTcsImV4cCI6MTY1Mjg5OTU5NywiYXVkIjoid3d3LmV4YW1wbGUuY29tIiwic3ViIjoianJvY2tldEBleGFtcGxlLmNvbSIsIkdpdmVuTmFtZSI6IkpvaG5ueSIsIlN1cm5hbWUiOiJSb2NrZXQiLCJuYW1lIjoiSm9obm55IFJvY2tldCIsImVtYWlsIjoianJvY2tldEBleGFtcGxlLmNvbSIsInBpY3R1cmUiOiJ3d3cuZXhhbXBsZS5jb20iLCJodHRwczovL3RyYWNlYWJsZS5haS9yb2xlcyI6WyJ0cmFjZWFibGUiLCJ1c2VyIiwiYmlsbGluZ19hZG1pbiJdfQ.xdWar7cgJ_5V3SgECanVtBMhxJGb-DbeIfrKSpAQLJM";
+  private final String emptyRolesJwt = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJPbmxpbmUgSldUIEJ1aWxkZXIiLCJpYXQiOjE2MjEzNjM1OTcsImV4cCI6MTY1Mjg5OTU5NywiYXVkIjoid3d3LmV4YW1wbGUuY29tIiwic3ViIjoianJvY2tldEBleGFtcGxlLmNvbSIsIkdpdmVuTmFtZSI6IkpvaG5ueSIsIlN1cm5hbWUiOiJSb2NrZXQiLCJuYW1lIjoiSm9obm55IFJvY2tldCIsImVtYWlsIjoianJvY2tldEBleGFtcGxlLmNvbSIsInBpY3R1cmUiOiJ3d3cuZXhhbXBsZS5jb20iLCJodHRwczovL3RyYWNlYWJsZS5haS9yb2xlcyI6W119.sFUMZNyypj379xy5P4kqTbBXBOR5XvX2nhpKx6YiiwU";
   private final String testJwtUserId = "jrocket@example.com";
   private final String testJwtName = "Johnny Rocket";
   private final String testJwtPictureUrl = "www.example.com";
@@ -63,5 +65,12 @@ class JwtParserTest {
     JwtParser parser = new JwtParser();
     Optional<Jwt> jwt = parser.fromJwt(testJwt);
     assertEquals(Optional.of(testRoles), jwt.flatMap(j -> Optional.of(j.getRoles())));
+  }
+
+  @Test
+  void testRolesAreEmptyIfRolesArrayIsEmptyInJwt() {
+    JwtParser parser = new JwtParser();
+    Optional<Jwt> jwt = parser.fromJwt(emptyRolesJwt);
+    assertEquals(Optional.of(Collections.emptySet()), jwt.flatMap(j -> Optional.of(j.getRoles())));
   }
 }

--- a/grpc-context-utils/src/test/java/org/hypertrace/core/grpcutils/context/JwtParserTest.java
+++ b/grpc-context-utils/src/test/java/org/hypertrace/core/grpcutils/context/JwtParserTest.java
@@ -65,21 +65,21 @@ class JwtParserTest {
   void testTraceableRolesCanBeParsedFromToken() {
     JwtParser parser = new JwtParser();
     Optional<Jwt> jwt = parser.fromJwt(testJwt);
-    assertEquals(Optional.of(testRoles), jwt.flatMap(j -> Optional.of(j.getRoles())));
+    assertEquals(Optional.of(testRoles), jwt.map(Jwt::getRoles));
   }
 
   @Test
   void testRolesAreEmptyIfRolesArrayIsEmptyInJwt() {
     JwtParser parser = new JwtParser();
     Optional<Jwt> jwt = parser.fromJwt(emptyRolesJwt);
-    assertEquals(Optional.of(Collections.emptySet()), jwt.flatMap(j -> Optional.of(j.getRoles())));
+    assertEquals(Optional.of(Collections.emptySet()), jwt.map(Jwt::getRoles));
   }
 
   @Test
   void testRolesAreEmptyIfRolesIfNoRolesClaimInToken() {
     JwtParser parser = new JwtParser();
     Optional<Jwt> jwt = parser.fromJwt(noRolesJwt);
-    assertEquals(Optional.of(Collections.emptySet()), jwt.flatMap(j -> Optional.of(j.getRoles())));
+    assertEquals(Optional.of(Collections.emptySet()), jwt.map(Jwt::getRoles));
   }
 
 }

--- a/grpc-context-utils/src/test/java/org/hypertrace/core/grpcutils/context/JwtParserTest.java
+++ b/grpc-context-utils/src/test/java/org/hypertrace/core/grpcutils/context/JwtParserTest.java
@@ -9,6 +9,9 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.Optional;
+import java.util.Set;
+
+import com.google.common.collect.ImmutableSet;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
 
@@ -19,6 +22,7 @@ class JwtParserTest {
   private final String testJwtName = "Johnny Rocket";
   private final String testJwtPictureUrl = "www.example.com";
   private final String testJwtEmail = "jrocket@example.com";
+  private final Set<String> testRoles = ImmutableSet.of("traceable", "user", "billing_admin");
 
   @Test
   void testGoodJwtParse() {
@@ -53,5 +57,12 @@ class JwtParserTest {
 
     assertEquals(Optional.empty(), parser.fromAuthHeader("Bad header"));
     verify(parser, times(0)).fromJwt(ArgumentMatchers.any());
+  }
+
+  @Test
+  void testTraceableRolesCanBeParsedFromToken() {
+    JwtParser parser = new JwtParser();
+    Optional<Jwt> jwt = parser.fromJwt(testJwt);
+    assertEquals(Optional.of(testRoles), jwt.flatMap(Jwt::getEmail));
   }
 }

--- a/grpc-context-utils/src/test/java/org/hypertrace/core/grpcutils/context/JwtParserTest.java
+++ b/grpc-context-utils/src/test/java/org/hypertrace/core/grpcutils/context/JwtParserTest.java
@@ -16,8 +16,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
 
 class JwtParserTest {
-  private final String testJwt =
-      "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJPbmxpbmUgSldUIEJ1aWxkZXIiLCJpYXQiOjE2MjEzNjM1OTcsImV4cCI6MTY1Mjg5OTU5NywiYXVkIjoid3d3LmV4YW1wbGUuY29tIiwic3ViIjoianJvY2tldEBleGFtcGxlLmNvbSIsIkdpdmVuTmFtZSI6IkpvaG5ueSIsIlN1cm5hbWUiOiJSb2NrZXQiLCJuYW1lIjoiSm9obm55IFJvY2tldCIsImVtYWlsIjoianJvY2tldEBleGFtcGxlLmNvbSIsInBpY3R1cmUiOiJ3d3cuZXhhbXBsZS5jb20iLCJSb2xlIjpbIk1hbmFnZXIiLCJQcm9qZWN0IEFkbWluaXN0cmF0b3IiXX0.aesOuNIamZkTMR30CBt0J9NMZZt9iLRETa5ayN_EcVs";
+  private final String testJwt = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJPbmxpbmUgSldUIEJ1aWxkZXIiLCJpYXQiOjE2MjEzNjM1OTcsImV4cCI6MTY1Mjg5OTU5NywiYXVkIjoid3d3LmV4YW1wbGUuY29tIiwic3ViIjoianJvY2tldEBleGFtcGxlLmNvbSIsIkdpdmVuTmFtZSI6IkpvaG5ueSIsIlN1cm5hbWUiOiJSb2NrZXQiLCJuYW1lIjoiSm9obm55IFJvY2tldCIsImVtYWlsIjoianJvY2tldEBleGFtcGxlLmNvbSIsInBpY3R1cmUiOiJ3d3cuZXhhbXBsZS5jb20iLCJodHRwczovL3RyYWNlYWJsZS5haS9yb2xlcyI6WyJ0cmFjZWFibGUiLCJ1c2VyIiwiYmlsbGluZ19hZG1pbiJdfQ.xdWar7cgJ_5V3SgECanVtBMhxJGb-DbeIfrKSpAQLJM";
   private final String testJwtUserId = "jrocket@example.com";
   private final String testJwtName = "Johnny Rocket";
   private final String testJwtPictureUrl = "www.example.com";
@@ -63,6 +62,6 @@ class JwtParserTest {
   void testTraceableRolesCanBeParsedFromToken() {
     JwtParser parser = new JwtParser();
     Optional<Jwt> jwt = parser.fromJwt(testJwt);
-    assertEquals(Optional.of(testRoles), jwt.flatMap(Jwt::getEmail));
+    assertEquals(Optional.of(testRoles), jwt.flatMap(j -> Optional.of(j.getRoles())));
   }
 }

--- a/grpc-context-utils/src/test/java/org/hypertrace/core/grpcutils/context/RequestContextTest.java
+++ b/grpc-context-utils/src/test/java/org/hypertrace/core/grpcutils/context/RequestContextTest.java
@@ -59,12 +59,12 @@ public class RequestContextTest {
     String jwt = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJPbmxpbmUgSldUIEJ1aWxkZXIiLCJpYXQiOjE2MjEzNjM1OTcsIm" +
         "V4cCI6MTY1Mjg5OTU5NywiYXVkIjoid3d3LmV4YW1wbGUuY29tIiwic3ViIjoianJvY2tldEBleGFtcGxlLmNvbSIsIkdpdmVuTmFtZSI6Ik" +
         "pvaG5ueSIsIlN1cm5hbWUiOiJSb2NrZXQiLCJuYW1lIjoiSm9obm55IFJvY2tldCIsImVtYWlsIjoianJvY2tldEBleGFtcGxlLmNvbSIsIn" +
-        "BpY3R1cmUiOiJ3d3cuZXhhbXBsZS5jb20iLCJodHRwczovL3RyYWNlYWJsZS5haS9yb2xlcyI6WyJzdXBlcl91c2VyIiwidXNlciIsImJpbG" +
-        "xpbmdfYWRtaW4iXX0.hcGrulbxkDDJhWuos18iQzpFjPBmlF6xt6wKusB2ZYg";
+        "BpY3R1cmUiOiJ3d3cuZXhhbXBsZS5jb20iLCJyb2xlcyI6WyJzdXBlcl91c2VyIiwidXNlciIsImJpbGxpbmdfYWRtaW4iXX0.lEDjPPCjr-" +
+        "Epv6pNslq-HK9vmxfstp1sY85GstlbU1I";
 
     RequestContext requestContext = new RequestContext();
     requestContext.add("authorization", "Bearer " + jwt);
-    List<String> actualRoles = requestContext.getRoles();
+    List<String> actualRoles = requestContext.getRoles("roles");
     assertEquals(expectedRoles, actualRoles);
   }
 }

--- a/grpc-context-utils/src/test/java/org/hypertrace/core/grpcutils/context/RequestContextTest.java
+++ b/grpc-context-utils/src/test/java/org/hypertrace/core/grpcutils/context/RequestContextTest.java
@@ -1,11 +1,10 @@
 package org.hypertrace.core.grpcutils.context;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 
-import com.google.common.collect.ImmutableSet;
-import org.junit.jupiter.api.Assertions;
+import com.google.common.collect.ImmutableList;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -56,16 +55,16 @@ public class RequestContextTest {
 
   @Test
   void testRolesArePropagatedInRequestContext() {
-    Set<String> expectedRoles = ImmutableSet.of("billing_admin", "user", "traceable");
+    List<String> expectedRoles = ImmutableList.of("super_user", "user", "billing_admin");
     String jwt = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJPbmxpbmUgSldUIEJ1aWxkZXIiLCJpYXQiOjE2MjEzNjM1OTcsIm" +
         "V4cCI6MTY1Mjg5OTU5NywiYXVkIjoid3d3LmV4YW1wbGUuY29tIiwic3ViIjoianJvY2tldEBleGFtcGxlLmNvbSIsIkdpdmVuTmFtZSI6Ik" +
         "pvaG5ueSIsIlN1cm5hbWUiOiJSb2NrZXQiLCJuYW1lIjoiSm9obm55IFJvY2tldCIsImVtYWlsIjoianJvY2tldEBleGFtcGxlLmNvbSIsIn" +
-        "BpY3R1cmUiOiJ3d3cuZXhhbXBsZS5jb20iLCJodHRwczovL3RyYWNlYWJsZS5haS9yb2xlcyI6WyJ0cmFjZWFibGUiLCJ1c2VyIiwiYmlsbG" +
-        "luZ19hZG1pbiJdfQ.xdWar7cgJ_5V3SgECanVtBMhxJGb-DbeIfrKSpAQLJM";
+        "BpY3R1cmUiOiJ3d3cuZXhhbXBsZS5jb20iLCJodHRwczovL3RyYWNlYWJsZS5haS9yb2xlcyI6WyJzdXBlcl91c2VyIiwidXNlciIsImJpbG" +
+        "xpbmdfYWRtaW4iXX0.hcGrulbxkDDJhWuos18iQzpFjPBmlF6xt6wKusB2ZYg";
 
     RequestContext requestContext = new RequestContext();
     requestContext.add("authorization", "Bearer " + jwt);
-    Set<String> actualRoles = requestContext.getRoles();
+    List<String> actualRoles = requestContext.getRoles();
     assertEquals(expectedRoles, actualRoles);
   }
 }

--- a/grpc-context-utils/src/test/java/org/hypertrace/core/grpcutils/context/RequestContextTest.java
+++ b/grpc-context-utils/src/test/java/org/hypertrace/core/grpcutils/context/RequestContextTest.java
@@ -2,8 +2,13 @@ package org.hypertrace.core.grpcutils.context;
 
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
+
+import com.google.common.collect.ImmutableSet;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /** Unit tests for {@link RequestContext} and utility methods in it. */
 public class RequestContextTest {
@@ -11,26 +16,26 @@ public class RequestContextTest {
   private static final String TEST_AUTH_HEADER = "Bearer sample-auth-header";
 
   @Test
-  public void testTenantId() {
+  void testTenantId() {
     RequestContext requestContext = new RequestContext();
     requestContext.add(RequestContextConstants.TENANT_ID_HEADER_KEY, TENANT_ID);
     Optional<String> tenantId = requestContext.getTenantId();
-    Assertions.assertEquals(Optional.of(TENANT_ID), tenantId);
+    assertEquals(Optional.of(TENANT_ID), tenantId);
 
     requestContext = new RequestContext();
     tenantId = requestContext.getTenantId();
-    Assertions.assertEquals(Optional.empty(), tenantId);
+    assertEquals(Optional.empty(), tenantId);
   }
 
   @Test
-  public void testGetRequestHeaders() {
+  void testGetRequestHeaders() {
     RequestContext requestContext = new RequestContext();
     requestContext.add(RequestContextConstants.AUTHORIZATION_HEADER, TEST_AUTH_HEADER);
     requestContext.add("x-some-tenant-header", "v1");
 
     Map<String, String> requestHeaders = requestContext.getRequestHeaders();
 
-    Assertions.assertEquals(
+    assertEquals(
         Map.of(
             RequestContextConstants.AUTHORIZATION_HEADER,
             TEST_AUTH_HEADER,
@@ -40,12 +45,27 @@ public class RequestContextTest {
   }
 
   @Test
-  public void testCreateForTenantId() {
+  void testCreateForTenantId() {
     RequestContext requestContext = RequestContext.forTenantId(TENANT_ID);
-    Assertions.assertEquals(Optional.of(TENANT_ID), requestContext.getTenantId());
-    Assertions.assertEquals(
+    assertEquals(Optional.of(TENANT_ID), requestContext.getTenantId());
+    assertEquals(
         Optional.of(TENANT_ID), requestContext.get(RequestContextConstants.TENANT_ID_HEADER_KEY));
-    Assertions.assertEquals(
+    assertEquals(
         Map.of(RequestContextConstants.TENANT_ID_HEADER_KEY, TENANT_ID), requestContext.getAll());
+  }
+
+  @Test
+  void testRolesArePropagatedInRequestContext() {
+    Set<String> expectedRoles = ImmutableSet.of("billing_admin", "user", "traceable");
+    String jwt = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJPbmxpbmUgSldUIEJ1aWxkZXIiLCJpYXQiOjE2MjEzNjM1OTcsIm" +
+        "V4cCI6MTY1Mjg5OTU5NywiYXVkIjoid3d3LmV4YW1wbGUuY29tIiwic3ViIjoianJvY2tldEBleGFtcGxlLmNvbSIsIkdpdmVuTmFtZSI6Ik" +
+        "pvaG5ueSIsIlN1cm5hbWUiOiJSb2NrZXQiLCJuYW1lIjoiSm9obm55IFJvY2tldCIsImVtYWlsIjoianJvY2tldEBleGFtcGxlLmNvbSIsIn" +
+        "BpY3R1cmUiOiJ3d3cuZXhhbXBsZS5jb20iLCJodHRwczovL3RyYWNlYWJsZS5haS9yb2xlcyI6WyJ0cmFjZWFibGUiLCJ1c2VyIiwiYmlsbG" +
+        "luZ19hZG1pbiJdfQ.xdWar7cgJ_5V3SgECanVtBMhxJGb-DbeIfrKSpAQLJM";
+
+    RequestContext requestContext = new RequestContext();
+    requestContext.add("authorization", "Bearer " + jwt);
+    Set<String> actualRoles = requestContext.getRoles();
+    assertEquals(expectedRoles, actualRoles);
   }
 }


### PR DESCRIPTION
## Description
Add roles parsing logic to JWT parser and expose roles in request context.
The main motivation is to be able to reuse this logic in other parts of codebase, specifically in graphql context

<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->


### Testing
Added unit tests

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules

### Documentation
Make sure that you have documented corresponding changes in this repository or [hypertrace docs repo](https://github.com/hypertrace/hypertrace-docs-website) if required.

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
