### PR TITLE
refactor: work in deadlines

### DIFF
--- a/grpc-client-utils/build.gradle.kts
+++ b/grpc-client-utils/build.gradle.kts
@@ -6,19 +6,11 @@ plugins {
 }
 
 dependencies {
+  api("io.grpc:grpc-context:1.40.0")
+  api("io.grpc:grpc-api:1.40.0")
+
   implementation(project(":grpc-context-utils"))
-
-  // Logging
   implementation("org.slf4j:slf4j-api:1.7.30")
-  // End Logging
-
-  // grpc
-  implementation("io.grpc:grpc-core:1.40.0")
-  constraints {
-    implementation("com.google.guava:guava:30.0-jre") {
-      because("https://snyk.io/vuln/SNYK-JAVA-COMGOOGLEGUAVA-1015415")
-    }
-  }
 
   testImplementation("org.junit.jupiter:junit-jupiter:5.7.0")
   testImplementation("org.mockito:mockito-core:3.12.1")

--- a/grpc-server-utils/build.gradle.kts
+++ b/grpc-server-utils/build.gradle.kts
@@ -10,19 +10,11 @@ tasks.test {
 }
 
 dependencies {
+  api("io.grpc:grpc-context:1.40.0")
+  api("io.grpc:grpc-api:1.40.0")
+
   implementation(project(":grpc-context-utils"))
-
-  // Logging
   implementation("org.slf4j:slf4j-api:1.7.30")
-  // End Logging
-
-  // grpc
-  implementation("io.grpc:grpc-core:1.40.0")
-  constraints {
-    implementation("com.google.guava:guava:30.0-jre") {
-      because("https://snyk.io/vuln/SNYK-JAVA-COMGOOGLEGUAVA-1015415")
-    }
-  }
 
   annotationProcessor("org.projectlombok:lombok:1.18.20")
   compileOnly("org.projectlombok:lombok:1.18.20")

--- a/grpc-server-utils/src/main/java/org/hypertrace/core/grpcutils/server/ServerManagementUtil.java
+++ b/grpc-server-utils/src/main/java/org/hypertrace/core/grpcutils/server/ServerManagementUtil.java
@@ -1,43 +1,56 @@
 package org.hypertrace.core.grpcutils.server;
 
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+import io.grpc.Deadline;
 import io.grpc.Server;
-import java.time.Duration;
-import java.util.concurrent.TimeUnit;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 public class ServerManagementUtil {
 
-  public static void shutdownServer(Server grpcServer, String name, Duration timeout) {
+  /**
+   * Attempts to gracefully shutdown the server by the provided deadline. If unsuccessful, it then
+   * uses up to 5 additional seconds to forcefully shutdown the server, returning with the final
+   * success status.
+   *
+   * @param grpcServer
+   * @param name
+   * @param deadline
+   * @return boolean - true if the server is terminated successfully, false otherwise
+   */
+  public static boolean shutdownServer(Server grpcServer, String name, Deadline deadline) {
     log.info("Starting shutdown for service [{}]", name);
     grpcServer.shutdown();
-    boolean gracefullyShutdown = waitForGracefulShutdown(grpcServer, name, timeout);
-    if (!gracefullyShutdown) {
-      forceShutdown(grpcServer, name);
-    }
+    return waitForGracefulShutdown(grpcServer, name, deadline)
+        || forceShutdown(grpcServer, name, deadline.offset(5, SECONDS));
   }
 
-  private static boolean waitForGracefulShutdown(Server grpcServer, String name, Duration timeout) {
-    boolean successfullyShutdown = waitForTermination(grpcServer, name, timeout);
+  private static boolean waitForGracefulShutdown(
+      Server grpcServer, String name, Deadline deadline) {
+    boolean successfullyShutdown = waitForTermination(grpcServer, name, deadline);
     if (successfullyShutdown) {
       log.info("Shutdown service successfully [{}]", name);
     }
     return successfullyShutdown;
   }
 
-  private static void forceShutdown(Server grpcServer, String name) {
+  private static boolean forceShutdown(Server grpcServer, String name, Deadline deadline) {
     log.error("Shutting down service [{}] forcefully", name);
     grpcServer.shutdownNow();
-    if (waitForTermination(grpcServer, name, Duration.ofSeconds(5))) {
+    boolean successfullyShutdown = waitForTermination(grpcServer, name, deadline);
+    if (successfullyShutdown) {
       log.error("Forced service [{}] shutdown successful", name);
     } else {
       log.error("Unable to force service [{}] shutdown in 5s - giving up!", name);
     }
+    return successfullyShutdown;
   }
 
-  private static boolean waitForTermination(Server grpcServer, String name, Duration deadline) {
+  private static boolean waitForTermination(Server grpcServer, String name, Deadline deadline) {
     try {
-      if (!grpcServer.awaitTermination(deadline.toMillis(), TimeUnit.MILLISECONDS)) {
+      if (!grpcServer.awaitTermination(deadline.timeRemaining(MILLISECONDS), MILLISECONDS)) {
         log.error("Service [{}] did not shut down after waiting", name);
       }
     } catch (InterruptedException ex) {


### PR DESCRIPTION
BREAKING CHANGE: changed new apis added in last release before they're adopted

## Description
The last release hasn't been adopted yet, so I'm taking the chance to improve some of the newly added APIs. This change should only break APIs added in `0.6.0`.

The changes: remove the usage of a clock, and instead take a deadline to both shutdown channels and shutdown servers. Before, the server shutdown was relative and the channel shutdown absolute (for consistency across each channel). The deadline addresses all concerns:
- It better matches other interactions with the grpc framework
- It retains the testability since a deadline can take a test ticker, and removes the need to pass in a clock
- It's absolute, so can be shared across multiple shutdowns
- It's defined relatively, which is how we normally invoke

### Testing
Updated unit tests.

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
