### PR TITLE
feat: upgrade jackson, grpc, constrain vulns and use bom

### DIFF
--- a/grpc-client-rx-utils/build.gradle.kts
+++ b/grpc-client-rx-utils/build.gradle.kts
@@ -6,20 +6,15 @@ plugins {
 }
 
 dependencies {
-  api("io.reactivex.rxjava3:rxjava:3.0.6")
-  api("io.grpc:grpc-stub:1.42.0")
+  api(platform("io.grpc:grpc-bom:1.43.1"))
+  api("io.reactivex.rxjava3:rxjava:3.1.3")
+  api("io.grpc:grpc-stub")
   api(project(":grpc-context-utils"))
-  implementation("io.grpc:grpc-context:1.42.0")
+  implementation("io.grpc:grpc-context")
 
-  constraints {
-    implementation("com.google.code.gson:gson:2.8.9") {
-      because("https://snyk.io/vuln/SNYK-JAVA-COMGOOGLECODEGSON-1730327")
-    }
-  }
-  
-  testImplementation("org.junit.jupiter:junit-jupiter:5.7.0")
-  testImplementation("org.mockito:mockito-core:3.12.1")
-  testImplementation("org.mockito:mockito-junit-jupiter:3.12.1")
+  testImplementation("org.junit.jupiter:junit-jupiter:5.8.2")
+  testImplementation("org.mockito:mockito-core:4.2.0")
+  testImplementation("org.mockito:mockito-junit-jupiter:4.2.0")
 }
 
 tasks.test {

--- a/grpc-client-utils/build.gradle.kts
+++ b/grpc-client-utils/build.gradle.kts
@@ -6,25 +6,20 @@ plugins {
 }
 
 dependencies {
-  api("io.grpc:grpc-context:1.42.0")
-  api("io.grpc:grpc-api:1.42.0")
+  api(platform("io.grpc:grpc-bom:1.43.1"))
+  api("io.grpc:grpc-context")
+  api("io.grpc:grpc-api")
 
   implementation(project(":grpc-context-utils"))
-  implementation("org.slf4j:slf4j-api:1.7.30")
+  implementation("org.slf4j:slf4j-api:1.7.32")
 
-  annotationProcessor("org.projectlombok:lombok:1.18.18")
-  compileOnly("org.projectlombok:lombok:1.18.18")
+  annotationProcessor("org.projectlombok:lombok:1.18.22")
+  compileOnly("org.projectlombok:lombok:1.18.22")
 
-  constraints {
-    implementation("com.google.code.gson:gson:2.8.9") {
-      because("https://snyk.io/vuln/SNYK-JAVA-COMGOOGLECODEGSON-1730327")
-    }
-  }
-
-  testImplementation("org.junit.jupiter:junit-jupiter:5.7.0")
-  testImplementation("org.mockito:mockito-core:3.12.1")
-  testImplementation("org.mockito:mockito-inline:3.12.1")
-  testRuntimeOnly("io.grpc:grpc-netty:1.42.0")
+  testImplementation("org.junit.jupiter:junit-jupiter:5.8.2")
+  testImplementation("org.mockito:mockito-core:4.2.0")
+  testImplementation("org.mockito:mockito-inline:4.2.0")
+  testRuntimeOnly("io.grpc:grpc-netty")
 }
 
 tasks.test {

--- a/grpc-context-utils/build.gradle.kts
+++ b/grpc-context-utils/build.gradle.kts
@@ -10,23 +10,29 @@ tasks.test {
 }
 
 dependencies {
-  // grpc
-  implementation("io.grpc:grpc-core:1.42.0")
+  api(platform("io.grpc:grpc-bom:1.43.1"))
+  implementation("io.grpc:grpc-core")
 
-  implementation("com.auth0:java-jwt:3.14.0")
-  implementation("com.auth0:jwks-rsa:0.17.0")
-  implementation("com.google.guava:guava:30.1-jre")
-
-  // Logging
-  implementation("org.slf4j:slf4j-api:1.7.30")
-  // End Logging
+  implementation("com.auth0:java-jwt:3.18.2")
+  implementation("com.auth0:jwks-rsa:0.20.0")
+  implementation("com.google.guava:guava:31.0.1-jre")
+  implementation("org.slf4j:slf4j-api:1.7.32")
 
   constraints {
-    implementation("com.google.code.gson:gson:2.8.9") {
+    api("com.fasterxml.jackson.core:jackson-databind:2.13.1") {
+      because("https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-232")
+    }
+    api("io.netty:netty-codec-http2:4.1.68.Final") {
+      because("Multiple vulnerabilities")
+    }
+    api("io.netty:netty-handler-proxy:4.1.71.Final"){
+      because("Multiple vulnerabilities")
+    }
+    api("com.google.code.gson:gson:2.8.9"){
       because("https://snyk.io/vuln/SNYK-JAVA-COMGOOGLECODEGSON-1730327")
     }
   }
 
-  testImplementation("org.junit.jupiter:junit-jupiter:5.7.0")
-  testImplementation("org.mockito:mockito-core:3.12.1")
+  testImplementation("org.junit.jupiter:junit-jupiter:5.8.2")
+  testImplementation("org.mockito:mockito-core:4.2.0")
 }

--- a/grpc-server-rx-utils/build.gradle.kts
+++ b/grpc-server-rx-utils/build.gradle.kts
@@ -6,26 +6,18 @@ plugins {
 }
 
 dependencies {
-  api("io.reactivex.rxjava3:rxjava:3.0.6")
-  api("io.grpc:grpc-stub:1.42.0")
+  api(platform("io.grpc:grpc-bom:1.43.1"))
+  api("io.reactivex.rxjava3:rxjava:3.1.3")
+  api("io.grpc:grpc-stub")
 
-  annotationProcessor("org.projectlombok:lombok:1.18.18")
-  compileOnly("org.projectlombok:lombok:1.18.18")
+  annotationProcessor("org.projectlombok:lombok:1.18.22")
+  compileOnly("org.projectlombok:lombok:1.18.22")
 
-  implementation("org.slf4j:slf4j-api:1.7.30")
-  
-  constraints {
-    implementation("com.google.guava:guava:30.1-jre") {
-      because("https://snyk.io/vuln/SNYK-JAVA-COMGOOGLEGUAVA-1015415")
-    }
-    implementation("com.google.code.gson:gson:2.8.9") {
-      because("https://snyk.io/vuln/SNYK-JAVA-COMGOOGLECODEGSON-1730327")
-    }
+  implementation("org.slf4j:slf4j-api:1.7.32")
 
-  }
-  testImplementation("org.junit.jupiter:junit-jupiter:5.7.0")
-  testImplementation("org.mockito:mockito-core:3.12.1")
-  testImplementation("org.mockito:mockito-junit-jupiter:3.12.1")
+  testImplementation("org.junit.jupiter:junit-jupiter:5.8.2")
+  testImplementation("org.mockito:mockito-core:4.2.0")
+  testImplementation("org.mockito:mockito-junit-jupiter:4.2.0")
 }
 
 tasks.test {

--- a/grpc-server-utils/build.gradle.kts
+++ b/grpc-server-utils/build.gradle.kts
@@ -10,15 +10,16 @@ tasks.test {
 }
 
 dependencies {
-  api("io.grpc:grpc-context:1.42.0")
-  api("io.grpc:grpc-api:1.42.0")
+  api(platform("io.grpc:grpc-bom:1.43.1"))
+  api("io.grpc:grpc-context")
+  api("io.grpc:grpc-api")
 
   implementation(project(":grpc-context-utils"))
-  implementation("org.slf4j:slf4j-api:1.7.30")
+  implementation("org.slf4j:slf4j-api:1.7.32")
 
-  annotationProcessor("org.projectlombok:lombok:1.18.20")
-  compileOnly("org.projectlombok:lombok:1.18.20")
+  annotationProcessor("org.projectlombok:lombok:1.18.22")
+  compileOnly("org.projectlombok:lombok:1.18.22")
 
-  testImplementation("org.junit.jupiter:junit-jupiter:5.7.0")
-  testImplementation("org.mockito:mockito-core:3.12.1")
+  testImplementation("org.junit.jupiter:junit-jupiter:5.8.2")
+  testImplementation("org.mockito:mockito-core:4.2.0")
 }


### PR DESCRIPTION
## Description
A number of things going on here. 
- Upgrading jackson and grpc along with some other minor dependencies
- Switching to using the grpc bom which will prevent other projects upgrading from getting out of sync
- Exposing constraints on known vulnerabilities that are associated with this at runtime: netty, jackson and gson 

### Testing
Published and verified locally
