### PR TITLE
feat: add support for more advanced contextual keys

### DIFF
--- a/grpc-context-utils/src/test/java/org/hypertrace/core/grpcutils/context/DefaultContextualKeyTest.java
+++ b/grpc-context-utils/src/test/java/org/hypertrace/core/grpcutils/context/DefaultContextualKeyTest.java
@@ -1,5 +1,6 @@
 package org.hypertrace.core.grpcutils.context;
 
+import static org.hypertrace.core.grpcutils.context.RequestContextConstants.TENANT_ID_HEADER_KEY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
@@ -10,6 +11,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -20,7 +22,8 @@ class DefaultContextualKeyTest {
   @Test
   void callsProvidedMethodsInContext() {
     RequestContext testContext = RequestContext.forTenantId("test-tenant");
-    ContextualKey<String> key = new DefaultContextualKey<>(testContext, "input");
+    ContextualKey<String> key =
+        new DefaultContextualKey<>(testContext, "input", List.of(TENANT_ID_HEADER_KEY));
 
     Function<String, String> testFunction =
         value ->
@@ -40,7 +43,8 @@ class DefaultContextualKeyTest {
   @Test
   void runsProvidedMethodInContext() {
     RequestContext testContext = RequestContext.forTenantId("test-tenant");
-    ContextualKey<String> key = new DefaultContextualKey<>(testContext, "input");
+    ContextualKey<String> key =
+        new DefaultContextualKey<>(testContext, "input", List.of(TENANT_ID_HEADER_KEY));
 
     Consumer<String> testConsumer = mock(Consumer.class);
 
@@ -67,19 +71,43 @@ class DefaultContextualKeyTest {
     RequestContext tenant2Context = RequestContext.forTenantId("second");
 
     assertEquals(
-        new DefaultContextualKey<>(tenant1Context, "input"),
-        new DefaultContextualKey<>(tenant1Context, "input"));
+        new DefaultContextualKey<>(tenant1Context, "input", List.of(TENANT_ID_HEADER_KEY)),
+        new DefaultContextualKey<>(tenant1Context, "input", List.of(TENANT_ID_HEADER_KEY)));
 
     assertEquals(
-        new DefaultContextualKey<>(tenant1Context, "input"),
-        new DefaultContextualKey<>(alternateTenant1Context, "input"));
+        new DefaultContextualKey<>(tenant1Context, "input", List.of(TENANT_ID_HEADER_KEY)),
+        new DefaultContextualKey<>(
+            alternateTenant1Context, "input", List.of(TENANT_ID_HEADER_KEY)));
 
     assertNotEquals(
-        new DefaultContextualKey<>(tenant1Context, "input"),
-        new DefaultContextualKey<>(tenant2Context, "input"));
+        new DefaultContextualKey<>(tenant1Context, "input", List.of(TENANT_ID_HEADER_KEY)),
+        new DefaultContextualKey<>(tenant2Context, "input", List.of(TENANT_ID_HEADER_KEY)));
 
     assertNotEquals(
-        new DefaultContextualKey<>(tenant1Context, "input"),
-        new DefaultContextualKey<>(tenant1Context, "other input"));
+        new DefaultContextualKey<>(tenant1Context, "input", List.of(TENANT_ID_HEADER_KEY)),
+        new DefaultContextualKey<>(tenant1Context, "other input", List.of(TENANT_ID_HEADER_KEY)));
+  }
+
+  @Test
+  void matchesMultipleHeaders() {
+    RequestContext firstContext = RequestContext.forTenantId("tenant");
+    firstContext.add("secondHeader", "second");
+    firstContext.add("thirdHeader", "third");
+
+    RequestContext secondContext = RequestContext.forTenantId("tenant");
+    secondContext.add("secondHeader", "second");
+    secondContext.add("thirdHeader", "fourth");
+
+    assertEquals(
+        new DefaultContextualKey<>(
+            firstContext, "input", List.of(TENANT_ID_HEADER_KEY, "secondHeader")),
+        new DefaultContextualKey<>(
+            secondContext, "input", List.of(TENANT_ID_HEADER_KEY, "secondHeader")));
+
+    assertNotEquals(
+        new DefaultContextualKey<>(
+            firstContext, "input", List.of(TENANT_ID_HEADER_KEY, "secondHeader", "thirdHeader")),
+        new DefaultContextualKey<>(
+            secondContext, "input", List.of(TENANT_ID_HEADER_KEY, "secondHeader", "thirdHeader")));
   }
 }


### PR DESCRIPTION
## Description
Previously, RequestContext could produce keys from the current request context that assumed it was triggered by a user. While this will always be correct, it can lead to duplication on internal calls where the specific auth context is less important. This extension allows support for both, deprecating the original to force the caller to make an explicit choice.


### Testing
Added UTs
