### PR TITLE
fix: add missing netty constraint on client utils

### DIFF
--- a/grpc-client-utils/build.gradle.kts
+++ b/grpc-client-utils/build.gradle.kts
@@ -6,6 +6,11 @@ plugins {
 }
 
 dependencies {
+  constraints {
+    api("io.netty:netty-codec-http2:4.1.77.Final") {
+      because("https://snyk.io/vuln/SNYK-JAVA-IONETTY-2812456")
+    }
+  }
   api(platform("io.grpc:grpc-bom:1.45.1"))
   api("io.grpc:grpc-context")
   api("io.grpc:grpc-api")


### PR DESCRIPTION
## Description
Previously we had only declared a netty constraint on our server util package, but both our grpc clients and servers use netty as transport. Adding the constraint to client lib here.
