### PR TITLE
feat: add in process channel support

### DIFF
--- a/grpc-client-utils/build.gradle.kts
+++ b/grpc-client-utils/build.gradle.kts
@@ -11,15 +11,16 @@ dependencies {
       because("https://snyk.io/vuln/SNYK-JAVA-IONETTY-2812456")
     }
   }
-  api(platform("io.grpc:grpc-bom:1.45.1"))
+  api(platform("io.grpc:grpc-bom:1.47.0"))
   api("io.grpc:grpc-context")
   api("io.grpc:grpc-api")
 
   implementation(project(":grpc-context-utils"))
   implementation("org.slf4j:slf4j-api:1.7.36")
+  implementation("io.grpc:grpc-core")
 
-  annotationProcessor("org.projectlombok:lombok:1.18.22")
-  compileOnly("org.projectlombok:lombok:1.18.22")
+  annotationProcessor("org.projectlombok:lombok:1.18.24")
+  compileOnly("org.projectlombok:lombok:1.18.24")
 
   testImplementation("org.junit.jupiter:junit-jupiter:5.8.2")
   testImplementation("org.mockito:mockito-core:4.4.0")

--- a/grpc-client-utils/src/main/java/org/hypertrace/core/grpcutils/client/InProcessGrpcChannelRegistry.java
+++ b/grpc-client-utils/src/main/java/org/hypertrace/core/grpcutils/client/InProcessGrpcChannelRegistry.java
@@ -1,0 +1,72 @@
+package org.hypertrace.core.grpcutils.client;
+
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import io.grpc.inprocess.InProcessChannelBuilder;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+public class InProcessGrpcChannelRegistry extends GrpcChannelRegistry {
+  private final Map<String, String> authorityToInProcessNamedOverride;
+
+  public InProcessGrpcChannelRegistry() {
+    this(Collections.emptyMap());
+  }
+
+  public InProcessGrpcChannelRegistry(Map<String, String> authorityToInProcessNamedOverride) {
+    this.authorityToInProcessNamedOverride = authorityToInProcessNamedOverride;
+  }
+
+  public InProcessGrpcChannelRegistry(GrpcChannelRegistry sourceRegistry) {
+    super(sourceRegistry);
+    if (sourceRegistry instanceof InProcessGrpcChannelRegistry) {
+      this.authorityToInProcessNamedOverride =
+          Map.copyOf(
+              ((InProcessGrpcChannelRegistry) sourceRegistry).authorityToInProcessNamedOverride);
+    } else {
+      this.authorityToInProcessNamedOverride = Collections.emptyMap();
+    }
+  }
+
+  public ManagedChannel forName(String name) {
+    return this.forName(name, GrpcChannelConfig.builder().build());
+  }
+
+  public ManagedChannel forName(String name, GrpcChannelConfig config) {
+    assert !this.isShutdown();
+    return this.getOrComputeChannel(
+        this.getInProcessChannelId(name, config), () -> this.buildInProcessChannel(name, config));
+  }
+
+  String getChannelId(String host, int port, boolean isPlaintext, GrpcChannelConfig config) {
+    return this.getInProcessOverrideNameForHostAndPort(host, port)
+        .map(name -> this.getInProcessChannelId(name, config))
+        .orElseGet(() -> super.getChannelId(host, port, isPlaintext, config));
+  }
+
+  @Override
+  ManagedChannelBuilder<?> getBuilderForAddress(String host, int port) {
+    return this.getInProcessOverrideNameForHostAndPort(host, port)
+        .<ManagedChannelBuilder<?>>map(InProcessChannelBuilder::forName)
+        .orElseGet(() -> super.getBuilderForAddress(host, port));
+  }
+
+  ManagedChannel buildInProcessChannel(String name, GrpcChannelConfig config) {
+    return this.configureAndBuildChannel(InProcessChannelBuilder.forName(name), config);
+  }
+
+  String getInProcessChannelId(String name, GrpcChannelConfig config) {
+    return "inprocess:" + name + ":" + Objects.hash(config);
+  }
+
+  private Optional<String> getInProcessOverrideNameForHostAndPort(String host, int port) {
+    return Optional.ofNullable(
+        this.authorityToInProcessNamedOverride.get(this.toAuthority(host, port)));
+  }
+
+  private String toAuthority(String host, int port) {
+    return host + ":" + port;
+  }
+}

--- a/grpc-client-utils/src/test/java/org/hypertrace/core/grpcutils/client/GrpcChannelRegistryTest.java
+++ b/grpc-client-utils/src/test/java/org/hypertrace/core/grpcutils/client/GrpcChannelRegistryTest.java
@@ -16,6 +16,7 @@ import io.grpc.Deadline;
 import io.grpc.Deadline.Ticker;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -126,5 +127,14 @@ class GrpcChannelRegistryTest {
     this.channelRegistry.shutdown();
     assertThrows(AssertionError.class, () -> this.channelRegistry.forPlaintextAddress("foo", 1000));
     assertThrows(AssertionError.class, () -> this.channelRegistry.forSecureAddress("foo", 1000));
+  }
+
+  @Test
+  void copyConstructorReusesExistingChannels() {
+    GrpcChannelRegistry firstRegistry = new GrpcChannelRegistry();
+
+    Channel firstChannel = firstRegistry.forSecureAddress("foo", 1000);
+
+    assertSame(firstChannel, new GrpcChannelRegistry(firstRegistry).forSecureAddress("foo", 1000));
   }
 }

--- a/grpc-client-utils/src/test/java/org/hypertrace/core/grpcutils/client/InProcessGrpcChannelRegistryTest.java
+++ b/grpc-client-utils/src/test/java/org/hypertrace/core/grpcutils/client/InProcessGrpcChannelRegistryTest.java
@@ -1,0 +1,77 @@
+package org.hypertrace.core.grpcutils.client;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import io.grpc.Channel;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class InProcessGrpcChannelRegistryTest {
+  InProcessGrpcChannelRegistry channelRegistry;
+
+  @BeforeEach
+  void beforeEach() {
+    this.channelRegistry = new InProcessGrpcChannelRegistry();
+  }
+
+  @Test
+  void createsNewChannelsAsRequested() {
+    // Regular channel
+    assertEquals("foo:1000", this.channelRegistry.forPlaintextAddress("foo", 1000).authority());
+    assertEquals("foo:1000", this.channelRegistry.forSecureAddress("foo", 1000).authority());
+    // In process runs on localhost
+    assertEquals("localhost", this.channelRegistry.forName("inprocess-name").authority());
+  }
+
+  @Test
+  void reusesInProcessChannels() {
+    assertSame(
+        this.channelRegistry.forName("inprocess-name"),
+        this.channelRegistry.forName("inprocess-name"));
+
+    // But not if their config differs
+    assertNotSame(
+        this.channelRegistry.forName("inprocess-name"),
+        this.channelRegistry.forName(
+            "inprocess-name", GrpcChannelConfig.builder().maxInboundMessageSize(100).build()));
+  }
+
+  @Test
+  void overridesAuthorityByConfig() {
+    this.channelRegistry = new InProcessGrpcChannelRegistry(Map.of("foo:1000", "inprocess-name"));
+    assertSame(
+        this.channelRegistry.forSecureAddress("foo", 1000),
+        this.channelRegistry.forName("inprocess-name"));
+    assertSame(
+        this.channelRegistry.forPlaintextAddress("foo", 1000),
+        this.channelRegistry.forName("inprocess-name"));
+    // Also works with custom config
+
+    assertSame(
+        this.channelRegistry.forSecureAddress(
+            "foo", 1000, GrpcChannelConfig.builder().maxInboundMessageSize(100).build()),
+        this.channelRegistry.forName(
+            "inprocess-name", GrpcChannelConfig.builder().maxInboundMessageSize(100).build()));
+
+    // but custom config shouldn't match the default config ones
+    assertNotSame(
+        this.channelRegistry.forSecureAddress("foo", 1000),
+        this.channelRegistry.forName(
+            "inprocess-name", GrpcChannelConfig.builder().maxInboundMessageSize(100).build()));
+  }
+
+  @Test
+  void copyConstructorReusesExistingChannelsAndOverrides() {
+    InProcessGrpcChannelRegistry firstRegistry =
+        new InProcessGrpcChannelRegistry(Map.of("foo:1000", "inprocess-name"));
+
+    Channel firstChannel = firstRegistry.forName("inprocess-name");
+
+    assertSame(
+        firstChannel,
+        new InProcessGrpcChannelRegistry(firstRegistry).forSecureAddress("foo", 1000));
+  }
+}


### PR DESCRIPTION
## Description
Add a version of the channel registry that supports in process channels as well as substituting an in process channel for a known hostname.

### Testing
Added unit tests

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
