### PR TITLE
refactor: use bom to constrain netty

### DIFF
--- a/grpc-client-utils/build.gradle.kts
+++ b/grpc-client-utils/build.gradle.kts
@@ -6,14 +6,13 @@ plugins {
 }
 
 dependencies {
-  constraints {
-    api("io.netty:netty-codec-http2:4.1.77.Final") {
-      because("https://snyk.io/vuln/SNYK-JAVA-IONETTY-2812456")
-    }
-  }
+
   api(platform("io.grpc:grpc-bom:1.47.0"))
   api("io.grpc:grpc-context")
   api("io.grpc:grpc-api")
+  api(platform("io.netty:netty-bom:4.1.79.Final")) {
+    because("https://snyk.io/vuln/SNYK-JAVA-IONETTY-2812456")
+  }
 
   implementation(project(":grpc-context-utils"))
   implementation("org.slf4j:slf4j-api:1.7.36")

--- a/grpc-server-utils/build.gradle.kts
+++ b/grpc-server-utils/build.gradle.kts
@@ -14,10 +14,8 @@ dependencies {
   api("io.grpc:grpc-context")
   api("io.grpc:grpc-api")
 
-  constraints {
-    api("io.netty:netty-codec-http2:4.1.77.Final") {
-      because("https://snyk.io/vuln/SNYK-JAVA-IONETTY-2812456")
-    }
+  api(platform("io.netty:netty-bom:4.1.79.Final")) {
+    because("https://snyk.io/vuln/SNYK-JAVA-IONETTY-2812456")
   }
 
   implementation(project(":grpc-context-utils"))


### PR DESCRIPTION
## Description
Previously we were constraining individually vulnerable jars, using the netty bom is a little more straightforward and makes sure all netty jars are on the same version.