### PR TITLE
refactor: add support for trailer building and update deps

### DIFF
--- a/grpc-context-utils/build.gradle.kts
+++ b/grpc-context-utils/build.gradle.kts
@@ -19,8 +19,12 @@ dependencies {
   implementation("org.slf4j:slf4j-api:1.7.36")
 
   constraints {
-    implementation("com.fasterxml.jackson.core:jackson-databind:2.13.4") {
-      because("https://nvd.nist.gov/vuln/detail/CVE-2022-42004")
+    implementation("com.fasterxml.jackson.core:jackson-databind:2.13.4.2") {
+      because("https://nvd.nist.gov/vuln/detail/CVE-2022-42003")
+    }
+    implementation("com.google.protobuf:protobuf-java:3.21.7") {
+      // Not used directly, but typically used together for since we always use proto and grpc together
+      because("CVE-2022-3171")
     }
   }
 

--- a/grpc-context-utils/src/main/java/org/hypertrace/core/grpcutils/context/RequestContext.java
+++ b/grpc-context-utils/src/main/java/org/hypertrace/core/grpcutils/context/RequestContext.java
@@ -1,11 +1,13 @@
 package org.hypertrace.core.grpcutils.context;
 
+import static io.grpc.Metadata.ASCII_STRING_MARSHALLER;
 import static org.hypertrace.core.grpcutils.context.RequestContextConstants.CACHE_MEANINGFUL_HEADERS;
 import static org.hypertrace.core.grpcutils.context.RequestContextConstants.TENANT_ID_HEADER_KEY;
 
 import com.google.common.collect.Maps;
 import io.grpc.Context;
 import io.grpc.Metadata;
+import io.grpc.Metadata.Key;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.HashMap;
@@ -181,6 +183,19 @@ public class RequestContext {
    */
   public <T> ContextualKey<T> buildInternalContextualKey(T data) {
     return new DefaultContextualKey<>(this, data, List.of(TENANT_ID_HEADER_KEY));
+  }
+
+  /** Converts the request context into metadata to be used as trailers */
+  public Metadata buildTrailers() {
+    Metadata trailers = new Metadata();
+    // For now, the only context item to use as a trailer is the request id
+    this.getRequestId()
+        .ifPresent(
+            requestId ->
+                trailers.put(
+                    Key.of(RequestContextConstants.REQUEST_ID_HEADER_KEY, ASCII_STRING_MARSHALLER),
+                    requestId));
+    return trailers;
   }
 
   private Map<String, String> getHeadersOtherThanAuth() {

--- a/grpc-context-utils/src/test/java/org/hypertrace/core/grpcutils/context/RequestContextTest.java
+++ b/grpc-context-utils/src/test/java/org/hypertrace/core/grpcutils/context/RequestContextTest.java
@@ -2,6 +2,7 @@ package org.hypertrace.core.grpcutils.context;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 import com.google.common.collect.ImmutableList;
 import io.grpc.Metadata;
@@ -155,5 +156,19 @@ public class RequestContextTest {
         requestContext.get(RequestContextConstants.TENANT_ID_METADATA_KEY.name()).get());
     Assertions.assertEquals(
         "AAARf5ZpQwlN/8FVe1axOPlaAQIdRU/Y8j0LAgE", requestContext.get("grpc-trace-bin").get());
+  }
+
+  @Test
+  public void buildsTrailers() {
+    RequestContext requestContext = RequestContext.forTenantId("test");
+
+    // Try building trailers and then request context from them.
+    RequestContext requestContextFromBuiltTrailers =
+        RequestContext.fromMetadata(requestContext.buildTrailers());
+
+    // Should not be equal because tenant id is not a trailer so should be lost
+    assertNotEquals(requestContext, requestContextFromBuiltTrailers);
+    // Request IDs should however be equal
+    assertEquals(requestContext.getRequestId(), requestContextFromBuiltTrailers.getRequestId());
   }
 }


### PR DESCRIPTION
## Description
Two parts
1. Updated dependencies. This involved a hotfix release for jackson databind that resolved a CVE, and adding a new constraint on proto. Although not directly used, its always used in conjunction with grpc so this was the best common place we had to constrain the version.
2. Added a way to build GRPC trailers from a request context. We already have this conversion as headers in the other direction, but this allows us to propagate things back (in my case, request IDs with errors).

### Testing
Added UTs

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
