### PR TITLE
feat: add context support for case insensitive and multivalue

### DIFF
--- a/grpc-client-rx-utils/build.gradle.kts
+++ b/grpc-client-rx-utils/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 dependencies {
-  api(platform("io.grpc:grpc-bom:1.45.1"))
+  api(platform("io.grpc:grpc-bom:1.50.0"))
   api("io.reactivex.rxjava3:rxjava:3.1.4")
   api("io.grpc:grpc-stub")
   api(project(":grpc-context-utils"))

--- a/grpc-client-utils/build.gradle.kts
+++ b/grpc-client-utils/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 
 dependencies {
 
-  api(platform("io.grpc:grpc-bom:1.47.0"))
+  api(platform("io.grpc:grpc-bom:1.50.0"))
   api("io.grpc:grpc-context")
   api("io.grpc:grpc-api")
   api(platform("io.netty:netty-bom:4.1.79.Final")) {

--- a/grpc-client-utils/src/main/java/org/hypertrace/core/grpcutils/client/RequestContextAsCreds.java
+++ b/grpc-client-utils/src/main/java/org/hypertrace/core/grpcutils/client/RequestContextAsCreds.java
@@ -6,8 +6,8 @@ import static io.grpc.Metadata.BINARY_BYTE_MARSHALLER;
 import io.grpc.CallCredentials;
 import io.grpc.Metadata;
 import io.grpc.Status;
-import java.util.Map;
 import org.hypertrace.core.grpcutils.context.RequestContext;
+import org.hypertrace.core.grpcutils.context.RequestContext.RequestContextHeader;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -28,17 +28,17 @@ public abstract class RequestContextAsCreds extends CallCredentials {
   protected void applyRequestContext(MetadataApplier applier, RequestContext requestContext) {
     Metadata metadata = new Metadata();
     if (requestContext != null) {
-      for (Map.Entry<String, String> entry : requestContext.getAll().entrySet()) {
+      for (RequestContextHeader header : requestContext.getAllHeaders()) {
         // Exclude null headers
-        if (entry.getValue() != null) {
-          String key = entry.getKey();
+        if (header.getValue() != null) {
+          String key = header.getName();
           if (key.toLowerCase().endsWith(Metadata.BINARY_HEADER_SUFFIX)) {
             metadata.put(
-                Metadata.Key.of(entry.getKey(), BINARY_BYTE_MARSHALLER),
-                entry.getValue().getBytes());
+                Metadata.Key.of(header.getName(), BINARY_BYTE_MARSHALLER),
+                header.getValue().getBytes());
           } else {
             metadata.put(
-                Metadata.Key.of(entry.getKey(), ASCII_STRING_MARSHALLER), entry.getValue());
+                Metadata.Key.of(header.getName(), ASCII_STRING_MARSHALLER), header.getValue());
           }
         }
       }

--- a/grpc-context-utils/build.gradle.kts
+++ b/grpc-context-utils/build.gradle.kts
@@ -10,13 +10,16 @@ tasks.test {
 }
 
 dependencies {
-  api(platform("io.grpc:grpc-bom:1.45.1"))
+  api(platform("io.grpc:grpc-bom:1.50.0"))
   implementation("io.grpc:grpc-core")
 
   implementation("com.auth0:java-jwt:3.19.1")
   implementation("com.auth0:jwks-rsa:0.21.1")
   implementation("com.google.guava:guava:31.1-jre")
   implementation("org.slf4j:slf4j-api:1.7.36")
+
+  annotationProcessor("org.projectlombok:lombok:1.18.24")
+  compileOnly("org.projectlombok:lombok:1.18.24")
 
   constraints {
     implementation("com.fasterxml.jackson.core:jackson-databind:2.13.4.2") {

--- a/grpc-context-utils/src/main/java/org/hypertrace/core/grpcutils/context/RequestContext.java
+++ b/grpc-context-utils/src/main/java/org/hypertrace/core/grpcutils/context/RequestContext.java
@@ -32,10 +32,9 @@ public class RequestContext {
   public static final Context.Key<RequestContext> CURRENT = Context.key("request_context");
 
   public static RequestContext forTenantId(String tenantId) {
-    RequestContext requestContext = new RequestContext();
-    requestContext.add(RequestContextConstants.TENANT_ID_HEADER_KEY, tenantId);
-    requestContext.add(RequestContextConstants.REQUEST_ID_HEADER_KEY, UUID.randomUUID().toString());
-    return requestContext;
+    return new RequestContext()
+        .put(RequestContextConstants.TENANT_ID_HEADER_KEY, tenantId)
+        .put(RequestContextConstants.REQUEST_ID_HEADER_KEY, UUID.randomUUID().toString());
   }
 
   public static RequestContext fromMetadata(Metadata metadata) {
@@ -59,7 +58,7 @@ public class RequestContext {
               }
               // The value could be null or empty for some keys so validate that.
               if (value != null && !value.isEmpty()) {
-                requestContext.add(k, value);
+                requestContext.put(k, value);
               }
             });
 
@@ -72,7 +71,7 @@ public class RequestContext {
 
   /** Reads tenant id from this RequestContext based on the tenant id http header and returns it. */
   public Optional<String> getTenantId() {
-    return get(RequestContextConstants.TENANT_ID_HEADER_KEY);
+    return getHeaderValue(RequestContextConstants.TENANT_ID_HEADER_KEY);
   }
 
   public Optional<String> getUserId() {
@@ -103,11 +102,12 @@ public class RequestContext {
   }
 
   public Optional<String> getRequestId() {
-    return this.get(RequestContextConstants.REQUEST_ID_HEADER_KEY);
+    return this.getHeaderValue(RequestContextConstants.REQUEST_ID_HEADER_KEY);
   }
 
   private Optional<Jwt> getJwt() {
-    return get(RequestContextConstants.AUTHORIZATION_HEADER).flatMap(jwtParser::fromAuthHeader);
+    return this.getHeaderValue(RequestContextConstants.AUTHORIZATION_HEADER)
+        .flatMap(jwtParser::fromAuthHeader);
   }
 
   /**

--- a/grpc-server-rx-utils/build.gradle.kts
+++ b/grpc-server-rx-utils/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 dependencies {
-  api(platform("io.grpc:grpc-bom:1.45.1"))
+  api(platform("io.grpc:grpc-bom:1.50.0"))
   api("io.reactivex.rxjava3:rxjava:3.1.4")
   api("io.grpc:grpc-stub")
 

--- a/grpc-server-utils/build.gradle.kts
+++ b/grpc-server-utils/build.gradle.kts
@@ -10,7 +10,7 @@ tasks.test {
 }
 
 dependencies {
-  api(platform("io.grpc:grpc-bom:1.45.1"))
+  api(platform("io.grpc:grpc-bom:1.50.0"))
   api("io.grpc:grpc-context")
   api("io.grpc:grpc-api")
 


### PR DESCRIPTION
## Description

The original implementation of request context assumed headers were case sensitive and single valued. I added support here for case insensitive access (preserving provided case on propagation), and accepting multiple values for the same header name.

Did my best to keep everything 100% backwards compatible if using the old APIs. The only exception I know of is using the deprecated `add` method, using two different cased representations for the same header name will result in an overwrite (which was the previous intention, and missing due to a bug), rather than an addition.


### Testing
Updated unit tests

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
