### PR TITLE
refactor: allow wrapping interceptors around service def

### DIFF
--- a/grpc-server-utils/src/main/java/org/hypertrace/core/grpcutils/server/InterceptorUtil.java
+++ b/grpc-server-utils/src/main/java/org/hypertrace/core/grpcutils/server/InterceptorUtil.java
@@ -17,4 +17,12 @@ public class InterceptorUtil {
     return ServerInterceptors.intercept(
         bindableService, new RequestContextServerInterceptor(), new ThrowableResponseInterceptor());
   }
+
+  public static ServerServiceDefinition wrapInterceptors(
+      ServerServiceDefinition serviceDefinition) {
+    return ServerInterceptors.intercept(
+        serviceDefinition,
+        new RequestContextServerInterceptor(),
+        new ThrowableResponseInterceptor());
+  }
 }


### PR DESCRIPTION
## Description
Small change to overload interceptor wrapper to allow accepting a service definition instead of a bindable service. This allows wrapping custom interceptors in addition to the util-defined ones.