### PR TITLE
feat: add registry-level client interceptor support

### DIFF
--- a/grpc-client-utils/src/main/java/org/hypertrace/core/grpcutils/client/GrpcRegistryConfig.java
+++ b/grpc-client-utils/src/main/java/org/hypertrace/core/grpcutils/client/GrpcRegistryConfig.java
@@ -1,0 +1,14 @@
+package org.hypertrace.core.grpcutils.client;
+
+import io.grpc.ClientInterceptor;
+import java.util.List;
+import lombok.Builder;
+import lombok.Singular;
+import lombok.Value;
+
+@Value
+@Builder(toBuilder = true)
+public class GrpcRegistryConfig {
+
+  @Singular List<ClientInterceptor> defaultInterceptors;
+}

--- a/grpc-client-utils/src/main/java/org/hypertrace/core/grpcutils/client/InProcessGrpcChannelRegistry.java
+++ b/grpc-client-utils/src/main/java/org/hypertrace/core/grpcutils/client/InProcessGrpcChannelRegistry.java
@@ -16,6 +16,16 @@ public class InProcessGrpcChannelRegistry extends GrpcChannelRegistry {
   }
 
   public InProcessGrpcChannelRegistry(Map<String, String> authorityToInProcessNamedOverride) {
+    this(authorityToInProcessNamedOverride, GrpcRegistryConfig.builder().build());
+  }
+
+  public InProcessGrpcChannelRegistry(GrpcRegistryConfig registryConfig) {
+    this(Collections.emptyMap(), registryConfig);
+  }
+
+  public InProcessGrpcChannelRegistry(
+      Map<String, String> authorityToInProcessNamedOverride, GrpcRegistryConfig registryConfig) {
+    super(registryConfig);
     this.authorityToInProcessNamedOverride = authorityToInProcessNamedOverride;
   }
 

--- a/grpc-client-utils/src/test/java/org/hypertrace/core/grpcutils/client/InProcessGrpcChannelRegistryTest.java
+++ b/grpc-client-utils/src/test/java/org/hypertrace/core/grpcutils/client/InProcessGrpcChannelRegistryTest.java
@@ -14,7 +14,6 @@ import static org.mockito.Mockito.when;
 import io.grpc.Channel;
 import io.grpc.ClientInterceptor;
 import io.grpc.ManagedChannel;
-import io.grpc.ManagedChannelBuilder;
 import io.grpc.inprocess.InProcessChannelBuilder;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;


### PR DESCRIPTION
## Description
Previously had to either add it on each registry channel call, or subclass the registry.

### Testing
Added UT

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
