### PR TITLE
fix: upgrade jwt lib due to breaking change

### DIFF
--- a/grpc-context-utils/build.gradle.kts
+++ b/grpc-context-utils/build.gradle.kts
@@ -13,8 +13,8 @@ dependencies {
   api(platform("io.grpc:grpc-bom:1.50.0"))
   implementation("io.grpc:grpc-core")
 
-  implementation("com.auth0:java-jwt:3.19.1")
-  implementation("com.auth0:jwks-rsa:0.21.1")
+  implementation("com.auth0:java-jwt:4.4.0")
+  implementation("com.auth0:jwks-rsa:0.22.0")
   implementation("com.google.guava:guava:31.1-jre")
   implementation("org.slf4j:slf4j-api:1.7.36")
 

--- a/grpc-context-utils/src/main/java/org/hypertrace/core/grpcutils/context/JwtParser.java
+++ b/grpc-context-utils/src/main/java/org/hypertrace/core/grpcutils/context/JwtParser.java
@@ -82,6 +82,7 @@ class JwtParser {
     public Optional<JwtClaim> getClaim(String claimName) {
       return Optional.of(jwt.getClaim(claimName))
           .filter(Predicate.not(Claim::isNull))
+          .filter(Predicate.not(Claim::isMissing))
           .map(DefaultJwtClaim::new);
     }
 


### PR DESCRIPTION
## Description
Breaking changes in auth0 lib lead to context breakage when running in same jvm as auth0 jwt 4+. Upgrading lib here for compat, and updating claim extraction based on new behavior.
