### PR TITLE
feat: standard exceptions

### DIFF
--- a/grpc-context-utils/src/main/java/org/hypertrace/core/grpcutils/context/ContextualExceptionDetails.java
+++ b/grpc-context-utils/src/main/java/org/hypertrace/core/grpcutils/context/ContextualExceptionDetails.java
@@ -17,7 +17,7 @@ public class ContextualExceptionDetails {
   @Nonnull RequestContext requestContext;
   @Nullable String externalMessage;
 
-  Optional<String> getExternalMessage() {
+  public Optional<String> getExternalMessage() {
     return Optional.ofNullable(this.externalMessage);
   }
 

--- a/grpc-context-utils/src/main/java/org/hypertrace/core/grpcutils/context/ContextualExceptionDetails.java
+++ b/grpc-context-utils/src/main/java/org/hypertrace/core/grpcutils/context/ContextualExceptionDetails.java
@@ -1,0 +1,47 @@
+package org.hypertrace.core.grpcutils.context;
+
+import io.grpc.Metadata;
+import io.grpc.Metadata.Key;
+import java.util.Optional;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Value;
+
+@Value
+@AllArgsConstructor(access = AccessLevel.PACKAGE)
+public class ContextualExceptionDetails {
+  static final Key<String> EXTERNAL_MESSAGE_KEY =
+      Key.of("external-message", Metadata.ASCII_STRING_MARSHALLER);
+  @Nonnull RequestContext requestContext;
+  @Nullable String externalMessage;
+
+  Optional<String> getExternalMessage() {
+    return Optional.ofNullable(this.externalMessage);
+  }
+
+  ContextualExceptionDetails(@Nonnull RequestContext requestContext) {
+    this(requestContext, null);
+  }
+
+  Metadata toMetadata() {
+    Metadata metadata = new Metadata();
+    this.getExternalMessage().ifPresent(value -> metadata.put(EXTERNAL_MESSAGE_KEY, value));
+    metadata.merge(this.getRequestContext().buildTrailers());
+    return metadata;
+  }
+
+  ContextualExceptionDetails withExternalMessage(@Nullable String externalMessage) {
+    return new ContextualExceptionDetails(this.getRequestContext(), externalMessage);
+  }
+
+  public static Optional<ContextualExceptionDetails> fromMetadata(Metadata metadata) {
+    RequestContext requestContext = RequestContext.fromMetadata(metadata);
+    if (requestContext.getRequestId().isEmpty()) {
+      return Optional.empty();
+    }
+    return Optional.of(
+        new ContextualExceptionDetails(requestContext, metadata.get(EXTERNAL_MESSAGE_KEY)));
+  }
+}

--- a/grpc-context-utils/src/main/java/org/hypertrace/core/grpcutils/context/ContextualStatusExceptionBuilder.java
+++ b/grpc-context-utils/src/main/java/org/hypertrace/core/grpcutils/context/ContextualStatusExceptionBuilder.java
@@ -1,0 +1,37 @@
+package org.hypertrace.core.grpcutils.context;
+
+import io.grpc.Status;
+import io.grpc.StatusException;
+import io.grpc.StatusRuntimeException;
+import javax.annotation.Nonnull;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class ContextualStatusExceptionBuilder {
+
+  private final Status status;
+  ContextualExceptionDetails details;
+
+  public static ContextualStatusExceptionBuilder from(Status status, RequestContext context) {
+    return new ContextualStatusExceptionBuilder(status, new ContextualExceptionDetails(context));
+  }
+
+  public ContextualStatusExceptionBuilder useStatusDescriptionAsExternalMessage() {
+    this.details = this.details.withExternalMessage(this.status.getDescription());
+    return this;
+  }
+
+  public ContextualStatusExceptionBuilder withExternalMessage(@Nonnull String externalMessage) {
+    this.details = this.details.withExternalMessage(externalMessage);
+    return this;
+  }
+
+  public StatusRuntimeException buildRuntimeException() {
+    return status.asRuntimeException(this.details.toMetadata());
+  }
+
+  public StatusException buildCheckedException() {
+    return status.asException(this.details.toMetadata());
+  }
+}

--- a/grpc-context-utils/src/main/java/org/hypertrace/core/grpcutils/context/ContextualStatusExceptionBuilder.java
+++ b/grpc-context-utils/src/main/java/org/hypertrace/core/grpcutils/context/ContextualStatusExceptionBuilder.java
@@ -6,7 +6,13 @@ import io.grpc.StatusRuntimeException;
 import javax.annotation.Nonnull;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
 
+@Getter
+@EqualsAndHashCode
+@ToString
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class ContextualStatusExceptionBuilder {
 

--- a/grpc-context-utils/src/main/java/org/hypertrace/core/grpcutils/context/RequestContext.java
+++ b/grpc-context-utils/src/main/java/org/hypertrace/core/grpcutils/context/RequestContext.java
@@ -279,13 +279,16 @@ public class RequestContext {
   /** Converts the request context into metadata to be used as trailers */
   public Metadata buildTrailers() {
     Metadata trailers = new Metadata();
-    // For now, the only context item to use as a trailer is the request id
+    // Propagate the tenant id and request id back
     this.getRequestId()
         .ifPresent(
             requestId ->
                 trailers.put(
                     Key.of(RequestContextConstants.REQUEST_ID_HEADER_KEY, ASCII_STRING_MARSHALLER),
                     requestId));
+    this.getTenantId()
+        .ifPresent(
+            tenantId -> trailers.put(RequestContextConstants.TENANT_ID_METADATA_KEY, tenantId));
     return trailers;
   }
 

--- a/grpc-context-utils/src/main/java/org/hypertrace/core/grpcutils/context/RequestContext.java
+++ b/grpc-context-utils/src/main/java/org/hypertrace/core/grpcutils/context/RequestContext.java
@@ -21,14 +21,17 @@ import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
+import lombok.EqualsAndHashCode;
 import lombok.Value;
 
 /**
  * Context of the GRPC request that should be carried and can made available to the services so that
  * the service can use them. We use this to propagate headers across services.
  */
+@EqualsAndHashCode
 public class RequestContext {
   public static final Context.Key<RequestContext> CURRENT = Context.key("request_context");
+  private static final JwtParser JWT_PARSER = new JwtParser();
 
   public static RequestContext forTenantId(String tenantId) {
     return new RequestContext()
@@ -68,7 +71,6 @@ public class RequestContext {
 
   private final ListMultimap<String, RequestContextHeader> headers =
       MultimapBuilder.linkedHashKeys().linkedListValues().build();
-  private final JwtParser jwtParser = new JwtParser();
 
   /** Reads tenant id from this RequestContext based on the tenant id http header and returns it. */
   public Optional<String> getTenantId() {
@@ -108,7 +110,7 @@ public class RequestContext {
 
   private Optional<Jwt> getJwt() {
     return this.getHeaderValue(RequestContextConstants.AUTHORIZATION_HEADER)
-        .flatMap(jwtParser::fromAuthHeader);
+        .flatMap(JWT_PARSER::fromAuthHeader);
   }
 
   /**

--- a/grpc-context-utils/src/test/java/org/hypertrace/core/grpcutils/context/ContextualExceptionDetailsTest.java
+++ b/grpc-context-utils/src/test/java/org/hypertrace/core/grpcutils/context/ContextualExceptionDetailsTest.java
@@ -1,0 +1,109 @@
+package org.hypertrace.core.grpcutils.context;
+
+import static io.grpc.Metadata.ASCII_STRING_MARSHALLER;
+import static org.hypertrace.core.grpcutils.context.ContextualExceptionDetails.EXTERNAL_MESSAGE_KEY;
+import static org.hypertrace.core.grpcutils.context.RequestContextConstants.REQUEST_ID_HEADER_KEY;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.grpc.Metadata;
+import io.grpc.Metadata.Key;
+import io.grpc.Status;
+import io.grpc.StatusException;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.Test;
+
+class ContextualExceptionDetailsTest {
+  static final String TEST_REQUEST_ID = "example-request-id";
+  static final RequestContext TEXT_CONTEXT =
+      new RequestContext().put(REQUEST_ID_HEADER_KEY, TEST_REQUEST_ID);
+
+  @Test
+  void convertsExceptionWithoutMessageToMetadata() {
+    StatusException exception =
+        ContextualStatusExceptionBuilder.from(
+                Status.INVALID_ARGUMENT.withDescription("Some internal description"), TEXT_CONTEXT)
+            .buildCheckedException();
+
+    assertEquals(
+        Map.of(REQUEST_ID_HEADER_KEY, TEST_REQUEST_ID), metadataAsMap(exception.getTrailers()));
+  }
+
+  @Test
+  void convertsExceptionWithDescriptionAsExternalMessageToMetadata() {
+    StatusException exception =
+        ContextualStatusExceptionBuilder.from(
+                Status.INVALID_ARGUMENT.withDescription("Some description"), TEXT_CONTEXT)
+            .useStatusDescriptionAsExternalMessage()
+            .buildCheckedException();
+
+    assertEquals(
+        Map.of(
+            REQUEST_ID_HEADER_KEY,
+            TEST_REQUEST_ID,
+            EXTERNAL_MESSAGE_KEY.originalName(),
+            "Some description"),
+        metadataAsMap(exception.getTrailers()));
+  }
+
+  @Test
+  void convertsExceptionWithCustomExternalMessageToMetadata() {
+    StatusException exception =
+        ContextualStatusExceptionBuilder.from(
+                Status.INVALID_ARGUMENT.withDescription("Some internal description"), TEXT_CONTEXT)
+            .withExternalMessage("custom external description")
+            .buildCheckedException();
+
+    assertEquals(
+        Map.of(
+            REQUEST_ID_HEADER_KEY,
+            TEST_REQUEST_ID,
+            EXTERNAL_MESSAGE_KEY.originalName(),
+            "custom external description"),
+        metadataAsMap(exception.getTrailers()));
+  }
+
+  @Test
+  void emptyIfUnableToParseContext() {
+    assertEquals(
+        Optional.empty(),
+        ContextualExceptionDetails.fromMetadata(
+            metadataFromMap(Map.of("random-key", "random-value"))));
+  }
+
+  @Test
+  void parsesMetadataWithoutMessage() {
+    assertEquals(
+        Optional.of(new ContextualExceptionDetails(TEXT_CONTEXT)),
+        ContextualExceptionDetails.fromMetadata(
+            metadataFromMap(Map.of(REQUEST_ID_HEADER_KEY, TEST_REQUEST_ID))));
+  }
+
+  @Test
+  void parsesMetadataWithMessage() {
+    assertEquals(
+        Optional.of(new ContextualExceptionDetails(TEXT_CONTEXT, "test message")),
+        ContextualExceptionDetails.fromMetadata(
+            metadataFromMap(
+                Map.of(
+                    REQUEST_ID_HEADER_KEY,
+                    TEST_REQUEST_ID,
+                    EXTERNAL_MESSAGE_KEY.originalName(),
+                    "test message"))));
+  }
+
+  Map<String, String> metadataAsMap(Metadata metadata) {
+    return metadata.keys().stream()
+        .collect(
+            Collectors.toUnmodifiableMap(
+                Function.identity(), key -> metadata.get(Key.of(key, ASCII_STRING_MARSHALLER))));
+  }
+
+  Metadata metadataFromMap(Map<String, String> metadataMap) {
+    Metadata metadata = new Metadata();
+    metadataMap.forEach((key, value) -> metadata.put(Key.of(key, ASCII_STRING_MARSHALLER), value));
+    return metadata;
+  }
+}

--- a/grpc-context-utils/src/test/java/org/hypertrace/core/grpcutils/context/RequestContextTest.java
+++ b/grpc-context-utils/src/test/java/org/hypertrace/core/grpcutils/context/RequestContextTest.java
@@ -161,16 +161,18 @@ public class RequestContextTest {
 
   @Test
   void buildsTrailers() {
-    RequestContext requestContext = RequestContext.forTenantId("test");
+    RequestContext requestContext =
+        RequestContext.forTenantId("test").put("other-header", "other-value");
 
     // Try building trailers and then request context from them.
     RequestContext requestContextFromBuiltTrailers =
         RequestContext.fromMetadata(requestContext.buildTrailers());
 
-    // Should not be equal because tenant id is not a trailer so should be lost
+    // Should not be equal because other header is not a trailer so should be lost
     assertNotEquals(requestContext, requestContextFromBuiltTrailers);
-    // Request IDs should however be equal
+    // Request ID and tenant ID should however be equal
     assertEquals(requestContext.getRequestId(), requestContextFromBuiltTrailers.getRequestId());
+    assertEquals(requestContext.getTenantId(), requestContextFromBuiltTrailers.getTenantId());
   }
 
   @Test

--- a/grpc-server-utils/src/main/java/org/hypertrace/core/grpcutils/server/ThrowableResponseInterceptor.java
+++ b/grpc-server-utils/src/main/java/org/hypertrace/core/grpcutils/server/ThrowableResponseInterceptor.java
@@ -6,6 +6,7 @@ import io.grpc.ServerCall;
 import io.grpc.ServerCallHandler;
 import io.grpc.ServerInterceptor;
 import io.grpc.Status;
+import org.hypertrace.core.grpcutils.context.RequestContext;
 
 /** Server Interceptor that decorates the error response status before closing the call */
 public class ThrowableResponseInterceptor implements ServerInterceptor {
@@ -28,6 +29,9 @@ public class ThrowableResponseInterceptor implements ServerInterceptor {
                   Status.INTERNAL
                       .withDescription(status.getCause().getMessage())
                       .withCause(status.getCause());
+            }
+            if (!status.isOk() && trailers.keys().isEmpty()) {
+              super.close(status, RequestContext.fromMetadata(headers).buildTrailers());
             }
             super.close(status, trailers);
           }


### PR DESCRIPTION
## Description

Add proposal for standard exceptions. Included tests that show how exceptions would be built.
Also:
- Server exception interceptor now sends request context back if trailers aren't already explicitly included
- RequestContext updated to include tenant id in trailers
- RequestContext now supports equals/hashcode
- RequestContext JWT Parser is now static and shared. This seems to match the original intent, as the JWT Parser includes a cache that would only make sense if shared across context. Should help avoid allocations and reduce JWT parsing.

Added UTs. Expect this to be fully backwards compatible.