### PR TITLE
chore: support initializing request id

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -21,11 +21,12 @@ jobs:
           args: build jacocoTestReport
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           name: unit test reports
           fail_ci_if_error: true
           flags: unit
+          token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: copy test reports
         uses: hypertrace/github-actions/gradle@main


### PR DESCRIPTION
## Description
This change updates the request interceptor to fill in the request ID if unset. Previously, we always did this in individual services at the edge but the default interceptor can support writing it if unset which automatically brings support to any GRPC services on the edge (only HTTP services will still need to manually support this).