### PR TITLE
Grpc cb utility update

### DIFF
--- a/grpc-circuitbreaker-utils/src/main/java/org/hypertrace/circuitbreaker/grpcutils/CircuitBreakerConfiguration.java
+++ b/grpc-circuitbreaker-utils/src/main/java/org/hypertrace/circuitbreaker/grpcutils/CircuitBreakerConfiguration.java
@@ -24,4 +24,7 @@ public class CircuitBreakerConfiguration<T> {
   @Builder.Default
   Function<String, StatusRuntimeException> exceptionBuilder =
       reason -> Status.RESOURCE_EXHAUSTED.withDescription(reason).asRuntimeException();
+
+  // config key to access non default circuit breaker thresholds
+  String configKey;
 }

--- a/grpc-circuitbreaker-utils/src/main/java/org/hypertrace/circuitbreaker/grpcutils/resilience/ResilienceCircuitBreakerConfigConverter.java
+++ b/grpc-circuitbreaker-utils/src/main/java/org/hypertrace/circuitbreaker/grpcutils/resilience/ResilienceCircuitBreakerConfigConverter.java
@@ -18,7 +18,7 @@ class ResilienceCircuitBreakerConfigConverter {
   public static List<String> getDisabledKeys(
       Map<String, CircuitBreakerThresholds> configurationMap) {
     return configurationMap.entrySet().stream()
-        .filter(entry -> entry.getValue().isEnabled())
+        .filter(entry -> !entry.getValue().isEnabled())
         .map(Map.Entry::getKey)
         .collect(Collectors.toList());
   }

--- a/grpc-circuitbreaker-utils/src/main/java/org/hypertrace/circuitbreaker/grpcutils/resilience/ResilienceCircuitBreakerFactory.java
+++ b/grpc-circuitbreaker-utils/src/main/java/org/hypertrace/circuitbreaker/grpcutils/resilience/ResilienceCircuitBreakerFactory.java
@@ -22,7 +22,8 @@ public class ResilienceCircuitBreakerFactory {
             resilienceCircuitBreakerConfigMap,
             ResilienceCircuitBreakerConfigConverter.getDisabledKeys(
                 circuitBreakerConfiguration.getCircuitBreakerThresholdsMap()),
-            circuitBreakerConfiguration.getDefaultThresholds().isEnabled());
+            circuitBreakerConfiguration.getDefaultThresholds().isEnabled(),
+            circuitBreakerConfiguration.getConfigKey());
     return new ResilienceCircuitBreakerInterceptor(
         circuitBreakerConfiguration, clock, resilienceCircuitBreakerProvider);
   }

--- a/grpc-circuitbreaker-utils/src/test/java/org/hypertrace/circuitbreaker/grpcutils/CircuitBreakerConfigParserTest.java
+++ b/grpc-circuitbreaker-utils/src/test/java/org/hypertrace/circuitbreaker/grpcutils/CircuitBreakerConfigParserTest.java
@@ -1,0 +1,79 @@
+package org.hypertrace.circuitbreaker.grpcutils;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import java.time.Duration;
+import java.util.Map;
+import org.hypertrace.circuitbreaker.grpcutils.CircuitBreakerThresholds.SlidingWindowType;
+import org.junit.jupiter.api.Test;
+
+class CircuitBreakerConfigParserTest {
+
+  @Test
+  void testParseConfig() {
+    String configStr =
+        "enabled = true\n" +
+            "defaultThresholds {\n" +
+            "  failureRateThreshold = 50.0\n" +
+            "  slowCallRateThreshold = 30.0\n" +
+            "  slowCallDurationThreshold = 1s\n" +
+            "  slidingWindowSize = 100\n" +
+            "  slidingWindowType = COUNT_BASED\n" +
+            "}\n" +
+            "service1 {\n" +
+            "  failureRateThreshold = 60.0\n" +
+            "  slowCallRateThreshold = 40.0\n" +
+            "  slowCallDurationThreshold = 2s\n" +
+            "  slidingWindowSize = 200\n" +
+            "  slidingWindowType = TIME_BASED\n" +
+            "}";
+
+    Config config = ConfigFactory.parseString(configStr);
+    CircuitBreakerConfiguration.CircuitBreakerConfigurationBuilder<Object> builder =
+        CircuitBreakerConfigParser.parseConfig(config);
+    CircuitBreakerConfiguration<Object> configuration = builder.build();
+
+    // Test enabled flag
+    assertTrue(configuration.isEnabled());
+
+    // Test default thresholds
+    CircuitBreakerThresholds defaultThresholds = configuration.getDefaultThresholds();
+    assertNotNull(defaultThresholds);
+    assertEquals(50.0f, defaultThresholds.getFailureRateThreshold());
+    assertEquals(30.0f, defaultThresholds.getSlowCallRateThreshold());
+    assertEquals(Duration.ofSeconds(1), defaultThresholds.getSlowCallDurationThreshold());
+    assertEquals(100, defaultThresholds.getSlidingWindowSize());
+    assertEquals(SlidingWindowType.COUNT_BASED, defaultThresholds.getSlidingWindowType());
+
+    // Test service specific thresholds
+    Map<String, CircuitBreakerThresholds> thresholdsMap = configuration.getCircuitBreakerThresholdsMap();
+    assertNotNull(thresholdsMap);
+    assertTrue(thresholdsMap.containsKey("service1"));
+
+    CircuitBreakerThresholds service1Thresholds = thresholdsMap.get("service1");
+    assertEquals(60.0f, service1Thresholds.getFailureRateThreshold());
+    assertEquals(40.0f, service1Thresholds.getSlowCallRateThreshold());
+    assertEquals(Duration.ofSeconds(2), service1Thresholds.getSlowCallDurationThreshold());
+    assertEquals(200, service1Thresholds.getSlidingWindowSize());
+    assertEquals(SlidingWindowType.TIME_BASED, service1Thresholds.getSlidingWindowType());
+  }
+
+  @Test
+  void testParseConfigWithMinimalConfig() {
+    String configStr = "{}";
+    Config config = ConfigFactory.parseString(configStr);
+    CircuitBreakerConfiguration.CircuitBreakerConfigurationBuilder<Object> builder =
+        CircuitBreakerConfigParser.parseConfig(config);
+    CircuitBreakerConfiguration<Object> configuration = builder.build();
+
+    // Test that defaults are used when no config is provided
+    assertFalse(configuration.isEnabled());
+    assertNotNull(configuration.getDefaultThresholds());
+    assertTrue(configuration.getCircuitBreakerThresholdsMap().isEmpty());
+  }
+}

--- a/grpc-circuitbreaker-utils/src/test/java/org/hypertrace/circuitbreaker/grpcutils/CircuitBreakerConfigParserTest.java
+++ b/grpc-circuitbreaker-utils/src/test/java/org/hypertrace/circuitbreaker/grpcutils/CircuitBreakerConfigParserTest.java
@@ -17,21 +17,21 @@ class CircuitBreakerConfigParserTest {
   @Test
   void testParseConfig() {
     String configStr =
-        "enabled = true\n" +
-            "defaultThresholds {\n" +
-            "  failureRateThreshold = 50.0\n" +
-            "  slowCallRateThreshold = 30.0\n" +
-            "  slowCallDurationThreshold = 1s\n" +
-            "  slidingWindowSize = 100\n" +
-            "  slidingWindowType = COUNT_BASED\n" +
-            "}\n" +
-            "service1 {\n" +
-            "  failureRateThreshold = 60.0\n" +
-            "  slowCallRateThreshold = 40.0\n" +
-            "  slowCallDurationThreshold = 2s\n" +
-            "  slidingWindowSize = 200\n" +
-            "  slidingWindowType = TIME_BASED\n" +
-            "}";
+        "enabled = true\n"
+            + "defaultThresholds {\n"
+            + "  failureRateThreshold = 50.0\n"
+            + "  slowCallRateThreshold = 30.0\n"
+            + "  slowCallDurationThreshold = 1s\n"
+            + "  slidingWindowSize = 100\n"
+            + "  slidingWindowType = COUNT_BASED\n"
+            + "}\n"
+            + "service1 {\n"
+            + "  failureRateThreshold = 60.0\n"
+            + "  slowCallRateThreshold = 40.0\n"
+            + "  slowCallDurationThreshold = 2s\n"
+            + "  slidingWindowSize = 200\n"
+            + "  slidingWindowType = TIME_BASED\n"
+            + "}";
 
     Config config = ConfigFactory.parseString(configStr);
     CircuitBreakerConfiguration.CircuitBreakerConfigurationBuilder<Object> builder =
@@ -51,7 +51,8 @@ class CircuitBreakerConfigParserTest {
     assertEquals(SlidingWindowType.COUNT_BASED, defaultThresholds.getSlidingWindowType());
 
     // Test service specific thresholds
-    Map<String, CircuitBreakerThresholds> thresholdsMap = configuration.getCircuitBreakerThresholdsMap();
+    Map<String, CircuitBreakerThresholds> thresholdsMap =
+        configuration.getCircuitBreakerThresholdsMap();
     assertNotNull(thresholdsMap);
     assertTrue(thresholdsMap.containsKey("service1"));
 

--- a/grpc-circuitbreaker-utils/src/test/java/org/hypertrace/circuitbreaker/grpcutils/resilience/ResilienceCircuitBreakerConfigConverterTest.java
+++ b/grpc-circuitbreaker-utils/src/test/java/org/hypertrace/circuitbreaker/grpcutils/resilience/ResilienceCircuitBreakerConfigConverterTest.java
@@ -58,22 +58,13 @@ public class ResilienceCircuitBreakerConfigConverterTest {
   void shouldGetDisabledKeys() {
     // Create a mix of enabled and disabled configurations
     CircuitBreakerThresholds enabledThresholds =
-        CircuitBreakerThresholds.builder()
-            .enabled(true)
-            .failureRateThreshold(50.0f)
-            .build();
+        CircuitBreakerThresholds.builder().enabled(true).failureRateThreshold(50.0f).build();
 
     CircuitBreakerThresholds disabledThresholds1 =
-        CircuitBreakerThresholds.builder()
-            .enabled(false)
-            .failureRateThreshold(50.0f)
-            .build();
+        CircuitBreakerThresholds.builder().enabled(false).failureRateThreshold(50.0f).build();
 
     CircuitBreakerThresholds disabledThresholds2 =
-        CircuitBreakerThresholds.builder()
-            .enabled(false)
-            .failureRateThreshold(60.0f)
-            .build();
+        CircuitBreakerThresholds.builder().enabled(false).failureRateThreshold(60.0f).build();
 
     Map<String, CircuitBreakerThresholds> configMap = new HashMap<>();
     configMap.put("enabledService", enabledThresholds);

--- a/grpc-circuitbreaker-utils/src/test/java/org/hypertrace/circuitbreaker/grpcutils/resilience/ResilienceCircuitBreakerProviderTest.java
+++ b/grpc-circuitbreaker-utils/src/test/java/org/hypertrace/circuitbreaker/grpcutils/resilience/ResilienceCircuitBreakerProviderTest.java
@@ -57,17 +57,16 @@ class ResilienceCircuitBreakerProviderTest {
     lenient().when(eventPublisher.onCallNotPermitted(any())).thenReturn(eventPublisher);
     lenient().doNothing().when(eventPublisher).onEvent(any());
 
-    lenient().when(circuitBreakerRegistry.circuitBreaker(eq(ENABLED_SERVICE), eq(serviceConfig)))
+    lenient()
+        .when(circuitBreakerRegistry.circuitBreaker(eq(ENABLED_SERVICE), eq(serviceConfig)))
         .thenReturn(mockCircuitBreaker);
-    lenient().when(circuitBreakerRegistry.circuitBreaker(eq(NON_CONFIGURED_SERVICE), eq(defaultConfig)))
+    lenient()
+        .when(circuitBreakerRegistry.circuitBreaker(eq(NON_CONFIGURED_SERVICE), eq(defaultConfig)))
         .thenReturn(mockCircuitBreaker);
 
-    provider = new ResilienceCircuitBreakerProvider(
-        circuitBreakerRegistry,
-        configMap,
-        disabledKeys,
-        true,
-        CONFIG_KEY);
+    provider =
+        new ResilienceCircuitBreakerProvider(
+            circuitBreakerRegistry, configMap, disabledKeys, true, CONFIG_KEY);
   }
 
   @Test
@@ -82,8 +81,7 @@ class ResilienceCircuitBreakerProviderTest {
     assertEquals(mockCircuitBreaker, secondResult.get());
 
     // Verify circuit breaker was created only once
-    verify(circuitBreakerRegistry, times(1))
-        .circuitBreaker(eq(ENABLED_SERVICE), eq(serviceConfig));
+    verify(circuitBreakerRegistry, times(1)).circuitBreaker(eq(ENABLED_SERVICE), eq(serviceConfig));
   }
 
   @Test
@@ -95,14 +93,16 @@ class ResilienceCircuitBreakerProviderTest {
   @Test
   void shouldReturnEmptyForNonConfiguredServiceWhenConfigKeyDisabled() {
     // Create provider with disabled config key
-    ResilienceCircuitBreakerProvider providerWithDisabledConfig = new ResilienceCircuitBreakerProvider(
-        circuitBreakerRegistry,
-        configMap,
-        Arrays.asList(DISABLED_SERVICE, CONFIG_KEY), // CONFIG_KEY is disabled
-        true,
-        CONFIG_KEY);
+    ResilienceCircuitBreakerProvider providerWithDisabledConfig =
+        new ResilienceCircuitBreakerProvider(
+            circuitBreakerRegistry,
+            configMap,
+            Arrays.asList(DISABLED_SERVICE, CONFIG_KEY), // CONFIG_KEY is disabled
+            true,
+            CONFIG_KEY);
 
-    Optional<CircuitBreaker> result = providerWithDisabledConfig.getCircuitBreaker(NON_CONFIGURED_SERVICE);
+    Optional<CircuitBreaker> result =
+        providerWithDisabledConfig.getCircuitBreaker(NON_CONFIGURED_SERVICE);
     assertFalse(result.isPresent());
   }
 
@@ -125,8 +125,7 @@ class ResilienceCircuitBreakerProviderTest {
     provider.getCircuitBreaker(ENABLED_SERVICE);
 
     // Verify circuit breaker was created only once despite multiple calls
-    verify(circuitBreakerRegistry, times(1))
-        .circuitBreaker(eq(ENABLED_SERVICE), eq(serviceConfig));
+    verify(circuitBreakerRegistry, times(1)).circuitBreaker(eq(ENABLED_SERVICE), eq(serviceConfig));
   }
 
   @Test
@@ -137,40 +136,49 @@ class ResilienceCircuitBreakerProviderTest {
     assertEquals(mockCircuitBreaker, serviceSpecificResult.get());
     verify(circuitBreakerRegistry).circuitBreaker(ENABLED_SERVICE, serviceConfig);
 
-    // Case 2: Service without specific config against circuit breaker key but with config present against config key
+    // Case 2: Service without specific config against circuit breaker key but with config present
+    // against config key
     String fallbackService = "fallbackService";
-    lenient().when(circuitBreakerRegistry.circuitBreaker(eq(fallbackService), eq(defaultConfig)))
+    lenient()
+        .when(circuitBreakerRegistry.circuitBreaker(eq(fallbackService), eq(defaultConfig)))
         .thenReturn(mockCircuitBreaker);
     Optional<CircuitBreaker> fallbackResult = provider.getCircuitBreaker(fallbackService);
     assertTrue(fallbackResult.isPresent());
     assertEquals(mockCircuitBreaker, fallbackResult.get());
     verify(circuitBreakerRegistry).circuitBreaker(fallbackService, defaultConfig);
 
-    // Case 3: Service with no config present against circuit breaker key and no config key, but defaultEnabled=true
+    // Case 3: Service with no config present against circuit breaker key and no config key, but
+    // defaultEnabled=true
     String noConfigService = "noConfigService";
-    ResilienceCircuitBreakerProvider defaultEnabledProvider = new ResilienceCircuitBreakerProvider(
-        circuitBreakerRegistry,
-        configMap,
-        disabledKeys,
-        true, // defaultEnabled = true
-        null); // no config key
+    ResilienceCircuitBreakerProvider defaultEnabledProvider =
+        new ResilienceCircuitBreakerProvider(
+            circuitBreakerRegistry,
+            configMap,
+            disabledKeys,
+            true, // defaultEnabled = true
+            null); // no config key
 
-    lenient().when(circuitBreakerRegistry.circuitBreaker(eq(noConfigService)))
+    lenient()
+        .when(circuitBreakerRegistry.circuitBreaker(eq(noConfigService)))
         .thenReturn(mockCircuitBreaker);
-    Optional<CircuitBreaker> noConfigResult = defaultEnabledProvider.getCircuitBreaker(noConfigService);
+    Optional<CircuitBreaker> noConfigResult =
+        defaultEnabledProvider.getCircuitBreaker(noConfigService);
     assertTrue(noConfigResult.isPresent());
     assertEquals(mockCircuitBreaker, noConfigResult.get());
     verify(circuitBreakerRegistry).circuitBreaker(noConfigService);
 
-    // Case 4: Service with no config present against circuit breaker key and no config key, and defaultEnabled=false
-    ResilienceCircuitBreakerProvider disabledDefaultProvider = new ResilienceCircuitBreakerProvider(
-        circuitBreakerRegistry,
-        configMap,
-        disabledKeys,
-        false, // defaultEnabled = false
-        null); // no config key
+    // Case 4: Service with no config present against circuit breaker key and no config key, and
+    // defaultEnabled=false
+    ResilienceCircuitBreakerProvider disabledDefaultProvider =
+        new ResilienceCircuitBreakerProvider(
+            circuitBreakerRegistry,
+            configMap,
+            disabledKeys,
+            false, // defaultEnabled = false
+            null); // no config key
 
-    Optional<CircuitBreaker> disabledDefaultResult = disabledDefaultProvider.getCircuitBreaker(noConfigService);
+    Optional<CircuitBreaker> disabledDefaultResult =
+        disabledDefaultProvider.getCircuitBreaker(noConfigService);
     assertFalse(disabledDefaultResult.isPresent());
   }
 }

--- a/grpc-circuitbreaker-utils/src/test/java/org/hypertrace/circuitbreaker/grpcutils/resilience/ResilienceCircuitBreakerProviderTest.java
+++ b/grpc-circuitbreaker-utils/src/test/java/org/hypertrace/circuitbreaker/grpcutils/resilience/ResilienceCircuitBreakerProviderTest.java
@@ -1,0 +1,131 @@
+package org.hypertrace.circuitbreaker.grpcutils.resilience;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import io.github.resilience4j.circuitbreaker.CircuitBreakerConfig;
+import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ResilienceCircuitBreakerProviderTest {
+
+  @Mock private CircuitBreakerRegistry circuitBreakerRegistry;
+  @Mock private CircuitBreaker mockCircuitBreaker;
+  @Mock private CircuitBreaker.EventPublisher eventPublisher;
+
+  private ResilienceCircuitBreakerProvider provider;
+  private Map<String, CircuitBreakerConfig> configMap;
+  private List<String> disabledKeys;
+  private static final String CONFIG_KEY = "defaultConfig";
+  private static final String ENABLED_SERVICE = "enabledService";
+  private static final String DISABLED_SERVICE = "disabledService";
+  private static final String NON_CONFIGURED_SERVICE = "nonConfiguredService";
+  private CircuitBreakerConfig defaultConfig;
+  private CircuitBreakerConfig serviceConfig;
+
+  @BeforeEach
+  void setup() {
+    defaultConfig = CircuitBreakerConfig.custom().build();
+    serviceConfig = CircuitBreakerConfig.custom().build();
+
+    configMap = new HashMap<>();
+    configMap.put(ENABLED_SERVICE, serviceConfig);
+    configMap.put(CONFIG_KEY, defaultConfig);
+
+    disabledKeys = Arrays.asList(DISABLED_SERVICE);
+
+    // Use lenient() for all mocks since they might not be used in every test
+    lenient().when(mockCircuitBreaker.getEventPublisher()).thenReturn(eventPublisher);
+    lenient().when(eventPublisher.onStateTransition(any())).thenReturn(eventPublisher);
+    lenient().when(eventPublisher.onCallNotPermitted(any())).thenReturn(eventPublisher);
+    lenient().doNothing().when(eventPublisher).onEvent(any());
+
+    lenient().when(circuitBreakerRegistry.circuitBreaker(eq(ENABLED_SERVICE), eq(serviceConfig)))
+        .thenReturn(mockCircuitBreaker);
+    lenient().when(circuitBreakerRegistry.circuitBreaker(eq(NON_CONFIGURED_SERVICE), eq(defaultConfig)))
+        .thenReturn(mockCircuitBreaker);
+
+    provider = new ResilienceCircuitBreakerProvider(
+        circuitBreakerRegistry,
+        configMap,
+        disabledKeys,
+        true,
+        CONFIG_KEY);
+  }
+
+  @Test
+  void shouldReturnCircuitBreakerForEnabledKey() {
+    Optional<CircuitBreaker> result = provider.getCircuitBreaker(ENABLED_SERVICE);
+    assertTrue(result.isPresent());
+    assertEquals(mockCircuitBreaker, result.get());
+
+    // Verify cache behavior by getting the same key again
+    Optional<CircuitBreaker> secondResult = provider.getCircuitBreaker(ENABLED_SERVICE);
+    assertTrue(secondResult.isPresent());
+    assertEquals(mockCircuitBreaker, secondResult.get());
+
+    // Verify circuit breaker was created only once
+    verify(circuitBreakerRegistry, times(1))
+        .circuitBreaker(eq(ENABLED_SERVICE), eq(serviceConfig));
+  }
+
+  @Test
+  void shouldReturnEmptyForDisabledKey() {
+    Optional<CircuitBreaker> result = provider.getCircuitBreaker(DISABLED_SERVICE);
+    assertFalse(result.isPresent());
+  }
+
+  @Test
+  void shouldReturnEmptyForNonConfiguredServiceWhenConfigKeyDisabled() {
+    // Create provider with disabled config key
+    ResilienceCircuitBreakerProvider providerWithDisabledConfig = new ResilienceCircuitBreakerProvider(
+        circuitBreakerRegistry,
+        configMap,
+        Arrays.asList(DISABLED_SERVICE, CONFIG_KEY), // CONFIG_KEY is disabled
+        true,
+        CONFIG_KEY);
+
+    Optional<CircuitBreaker> result = providerWithDisabledConfig.getCircuitBreaker(NON_CONFIGURED_SERVICE);
+    assertFalse(result.isPresent());
+  }
+
+  @Test
+  void shouldReturnCircuitBreakerForNonConfiguredServiceWhenConfigKeyEnabled() {
+    Optional<CircuitBreaker> result = provider.getCircuitBreaker(NON_CONFIGURED_SERVICE);
+    assertTrue(result.isPresent());
+    assertEquals(mockCircuitBreaker, result.get());
+
+    // Verify it used the default config
+    verify(circuitBreakerRegistry, times(1))
+        .circuitBreaker(eq(NON_CONFIGURED_SERVICE), eq(defaultConfig));
+  }
+
+  @Test
+  void shouldCacheCircuitBreakerInstances() {
+    // Get the same circuit breaker multiple times
+    provider.getCircuitBreaker(ENABLED_SERVICE);
+    provider.getCircuitBreaker(ENABLED_SERVICE);
+    provider.getCircuitBreaker(ENABLED_SERVICE);
+
+    // Verify circuit breaker was created only once despite multiple calls
+    verify(circuitBreakerRegistry, times(1))
+        .circuitBreaker(eq(ENABLED_SERVICE), eq(serviceConfig));
+  }
+}


### PR DESCRIPTION
## Description
Added config key support to define nested (channel level) configurations.

For Ex : 
Circuit Breaker Key - TenantId (defined by key function)
Config Key : S3 (notification channel)
Even though circuit breaker objects can be different for different tenants, we can define the CB configuration at channel level

### Testing
Tested changes on sandbox environment using this utility. Unit Tests added and validated.
Scenarios : 
1. Thresholds defined for circuit breaker key => should pick thresholds against circuit breaker key 
2. Thresholds not defined for circuit breaker key
	i. Config Key Set, Thresholds defined for config key => should pick thresholds against config key
	ii. Config Key Set, Thresholds not defined for config key => should pick default thresholds
	iii. Config key not set => should pick default thresholds
	
Jira : https://harness.atlassian.net/browse/ENGTAI-60244